### PR TITLE
ci: add CI/CD pipeline with automated testing and PyPI releases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+<!-- Brief description of the changes -->
+
+## Type of Change
+
+- [ ] `feat`: New feature (minor version bump)
+- [ ] `fix`: Bug fix (patch version bump)
+- [ ] `perf`: Performance improvement (patch version bump)
+- [ ] `refactor`: Code refactoring (patch version bump)
+- [ ] `docs`: Documentation only (no release)
+- [ ] `test`: Tests only (no release)
+- [ ] `ci`: CI/CD changes (no release)
+- [ ] `chore`: Maintenance (no release)
+
+## Testing
+
+- [ ] Tests pass locally (`pytest tests/ -v --tb=short --ignore=tests/agents/`)
+- [ ] Linting passes (`black --check src/ tests/ --line-length 100 && ruff check src/ tests/`)
+- [ ] New tests added for new functionality (if applicable)
+
+## Conventional Commits
+
+> **Reminder:** The PR title becomes the commit message on `main` after squash merge.
+> Use the format: `type(scope): description`
+>
+> Examples: `feat(codebase): add ONNX export support`, `fix(benchmark): correct latency calculation`
+
+## Notes for Reviewers
+
+<!-- Optional: anything reviewers should know -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+name: CI
+
+on:
+  push:
+    branches-ignore:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install linters
+        run: pip install black ruff
+
+      - name: Black check
+        run: black --check src/ tests/ --line-length 100
+
+      - name: Ruff check
+        run: ruff check src/ tests/
+
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    needs: lint
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install CPU-only PyTorch
+        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Install package with dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: |
+          pytest tests/ -v --tb=short -x --ignore=tests/agents/ \
+            ${{ matrix.python-version == '3.11' && '--cov=src/embodied_ai_architect --cov-report=term-missing' || '' }}
+
+  test-optional-deps:
+    name: Test (optional deps)
+    needs: lint
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install CPU-only PyTorch
+        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Install package with optimization deps
+        run: pip install -e ".[dev,optimization]"
+
+      - name: Run MOO tests
+        run: |
+          pytest tests/test_moo_*.py tests/test_bayesian_*.py -v --tb=short \
+            --ignore=tests/agents/ || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "docs-site/**"
+      - "docs/**"
+      - "*.md"
+
+jobs:
+  test:
+    name: Test (release gate)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install CPU-only PyTorch
+        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Install package with dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest tests/ -v --tb=short -x --ignore=tests/agents/
+
+  release:
+    name: Release
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write  # For OIDC PyPI publishing (future)
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install python-semantic-release build
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Semantic release version
+        id: version
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          semantic-release version
+          echo "released=$(git diff HEAD~1 --name-only | grep -c pyproject.toml || true)" >> $GITHUB_OUTPUT
+
+      - name: Build package
+        if: steps.version.outputs.released != '0'
+        run: python -m build
+
+      - name: Semantic release publish
+        if: steps.version.outputs.released != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: semantic-release publish
+
+      # PyPI publishing via API token
+      # To migrate to OIDC trusted publishers:
+      #   1. Remove PYPI_API_TOKEN secret
+      #   2. Configure trusted publisher at pypi.org/manage/project/.../settings/publishing/
+      #   3. Uncomment the pypa/gh-action-pypi-publish block below and remove the twine block
+      - name: Publish to PyPI
+        if: steps.version.outputs.released != '0'
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          pip install twine
+          twine upload dist/*
+
+      # OIDC trusted publisher (uncomment when ready):
+      # - name: Publish to PyPI (OIDC)
+      #   if: steps.version.outputs.released != '0'
+      #   uses: pypa/gh-action-pypi-publish@release/v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,97 @@
+# Contributing to Embodied AI Architect
+
+## Development Setup
+
+```bash
+# Clone and install in development mode
+git clone <repo-url>
+cd embodied-ai-architect
+pip install -e ".[dev]"
+```
+
+## Workflow
+
+We use a **feature branch workflow** with squash merges to `main`.
+
+### 1. Create a Feature Branch
+
+```bash
+git checkout -b feat/my-feature main
+```
+
+### 2. Make Changes and Test Locally
+
+```bash
+# Run linting
+black --check src/ tests/ --line-length 100
+ruff check src/ tests/
+
+# Run tests
+pytest tests/ -v --tb=short --ignore=tests/agents/
+
+# Auto-format
+black src/ tests/ --line-length 100
+```
+
+### 3. Commit with Conventional Commits
+
+We use [Conventional Commits](https://www.conventionalcommits.org/) for automatic versioning and releases.
+
+| Prefix | Example | Release |
+|--------|---------|---------|
+| `feat` | `feat(codebase): add ONNX export` | Minor (0.X.0) |
+| `fix` | `fix(benchmark): correct latency calc` | Patch (0.0.X) |
+| `perf` | `perf(pipeline): batch inference` | Patch (0.0.X) |
+| `refactor` | `refactor(agents): simplify base class` | Patch (0.0.X) |
+| `docs` | `docs: update README` | No release |
+| `test` | `test: add hardware profile tests` | No release |
+| `ci` | `ci: add Python 3.12 to matrix` | No release |
+| `chore` | `chore: update dependencies` | No release |
+
+**Breaking changes:** Add `BREAKING CHANGE:` in the commit footer or `!` after the type (e.g., `feat!: ...`) for a major version bump.
+
+### 4. Push and Open a PR
+
+```bash
+git push -u origin feat/my-feature
+```
+
+Open a PR targeting `main`. CI will run automatically:
+- **Lint** — Black + Ruff formatting and style checks
+- **Test** — Full test suite on Python 3.11 and 3.12
+- **Test (optional deps)** — Optimization tests (non-blocking)
+
+### 5. Squash Merge
+
+PRs are squash-merged. **The PR title becomes the commit message on `main`**, so use conventional commit format for your PR title:
+
+```
+feat(codebase): add ONNX export support
+```
+
+After merge, `python-semantic-release` automatically:
+1. Determines the version bump from the commit message
+2. Updates `pyproject.toml` version
+3. Creates a git tag (e.g., `v0.6.0`)
+4. Publishes to PyPI
+
+## Testing Optional Dependencies
+
+Some tests require optional packages (botorch, pymoo, langgraph). These tests auto-skip if the dependency isn't installed.
+
+```bash
+# Install optimization deps and run those tests
+pip install -e ".[dev,optimization]"
+pytest tests/test_moo_*.py tests/test_bayesian_*.py -v
+
+# Install chat deps
+pip install -e ".[dev,chat]"
+```
+
+## Code Style
+
+- **Line length:** 100 characters
+- **Python:** 3.11+
+- **Formatter:** Black
+- **Linter:** Ruff
+- **Type hints:** Required for public APIs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
     "pytest-cov>=4.0.0",
     "black>=23.0.0",
     "ruff>=0.1.0",
+    "build>=1.0.0",
 ]
 remote = [
     "paramiko>=3.0.0",  # SSH connections
@@ -91,11 +92,26 @@ where = ["src"]
 
 [tool.black]
 line-length = 100
-target-version = ['py39']
+target-version = ['py311']
 
 [tool.ruff]
 line-length = 100
-target-version = "py39"
+target-version = "py311"
+
+[tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]
+branch = "main"
+build_command = "python -m build"
+commit_message = "chore(release): {version}"
+tag_format = "v{version}"
+
+[tool.semantic_release.changelog]
+changelog_file = false
+
+[tool.semantic_release.commit_parser_options]
+allowed_tags = ["feat", "fix", "docs", "chore", "refactor", "test", "ci", "perf", "style"]
+minor_tags = ["feat"]
+patch_tags = ["fix", "perf", "refactor"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
- Add GitHub Actions CI workflow: lint (Black + Ruff), test matrix (Python 3.11/3.12 with CPU-only PyTorch), optional-deps job
- Add release workflow: semantic-release version bumps, PyPI publishing on merge to main
- Add semantic-release config to pyproject.toml
- Add build dependency to dev extras
- Update Black/Ruff target-version from py39 to py311
- Add PR template with conventional commits reminder
- Add CONTRIBUTING.md documenting feature branch workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidelines and pull request template to streamline development workflows.

* **Chores**
  * Established automated testing and linting workflows across Python 3.11 and 3.12.
  * Configured automated release process with version management.
  * Updated project configuration for modern Python versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->