### PR TITLE
fix(release): fix release workflow using non-existent GH_TOKEN secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@v5
         with:
@@ -58,7 +58,7 @@ jobs:
       - name: Semantic release version
         id: version
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           semantic-release version
           echo "released=$(git diff HEAD~1 --name-only | grep -c pyproject.toml || true)" >> $GITHUB_OUTPUT
@@ -70,7 +70,7 @@ jobs:
       - name: Semantic release publish
         if: steps.version.outputs.released != '0'
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: semantic-release publish
 
       # PyPI publishing via API token


### PR DESCRIPTION
Replace secrets.GH_TOKEN with secrets.GITHUB_TOKEN (the automatic token provided by GitHub Actions) in all three references.

## Summary

<!-- Brief description of the changes -->

## Type of Change

- [ ] `feat`: New feature (minor version bump)
- [x] `fix`: Bug fix (patch version bump)
- [ ] `perf`: Performance improvement (patch version bump)
- [ ] `refactor`: Code refactoring (patch version bump)
- [ ] `docs`: Documentation only (no release)
- [ ] `test`: Tests only (no release)
- [ ] `ci`: CI/CD changes (no release)
- [ ] `chore`: Maintenance (no release)

## Testing

- [x] Tests pass locally (`pytest tests/ -v --tb=short --ignore=tests/agents/`)
- [x] Linting passes (`black --check src/ tests/ --line-length 100 && ruff check src/ tests/`)
- [ ] New tests added for new functionality (if applicable)

## Conventional Commits

> **Reminder:** The PR title becomes the commit message on `main` after squash merge.
> Use the format: `type(scope): description`
>
> Examples: `feat(codebase): add ONNX export support`, `fix(benchmark): correct latency calculation`

## Notes for Reviewers

<!-- Optional: anything reviewers should know -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration for improved deployment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->