### PR TITLE
ci: fix semantic-release changelog_file config type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ commit_message = "chore(release): {version}"
 tag_format = "v{version}"
 
 [tool.semantic_release.changelog]
-changelog_file = false
+changelog_file = ""
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = ["feat", "fix", "docs", "chore", "refactor", "test", "ci", "perf", "style"]


### PR DESCRIPTION
Changed from boolean `false` to empty string `""` to satisfy pydantic validation in newer python-semantic-release versions.

## Summary

<!-- Brief description of the changes -->

## Type of Change

- [ ] `feat`: New feature (minor version bump)
- [x] `fix`: Bug fix (patch version bump)
- [ ] `perf`: Performance improvement (patch version bump)
- [ ] `refactor`: Code refactoring (patch version bump)
- [ ] `docs`: Documentation only (no release)
- [ ] `test`: Tests only (no release)
- [ ] `ci`: CI/CD changes (no release)
- [ ] `chore`: Maintenance (no release)

## Testing

- [x] Tests pass locally (`pytest tests/ -v --tb=short --ignore=tests/agents/`)
- [x] Linting passes (`black --check src/ tests/ --line-length 100 && ruff check src/ tests/`)
- [ ] New tests added for new functionality (if applicable)

## Conventional Commits

> **Reminder:** The PR title becomes the commit message on `main` after squash merge.
> Use the format: `type(scope): description`
>
> Examples: `feat(codebase): add ONNX export support`, `fix(benchmark): correct latency calculation`

## Notes for Reviewers

<!-- Optional: anything reviewers should know -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release tooling configuration for changelog handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->