### PR TITLE
feat(moo): wire MOO explorer output to optimization review snapshot

### DIFF
--- a/src/embodied_ai_architect/api/server.py
+++ b/src/embodied_ai_architect/api/server.py
@@ -124,9 +124,12 @@ def _build_router():
         pareto_results = state.get("pareto_results", {})
         opt_snap = state.get("optimization_review_snapshot", {})
 
+        # Front indices: non-dominated points only
+        front_indices = [i for i, p in enumerate(pareto_points) if not p.get("dominated", False)]
+
         return ParetoResponse(
             points=pareto_points,
-            front=pareto_results.get("front", []),
+            front=front_indices,
             knee_point_index=pareto_results.get("knee_point_index"),
             pareto_front_size=opt_snap.get("pareto_front_size", len(pareto_points)),
             hypervolume=opt_snap.get("hypervolume"),

--- a/src/embodied_ai_architect/graphs/moo/specialist.py
+++ b/src/embodied_ai_architect/graphs/moo/specialist.py
@@ -19,6 +19,38 @@ from embodied_ai_architect.graphs.task_graph import TaskNode
 logger = logging.getLogger(__name__)
 
 
+def _pareto_front_to_points(pareto_front: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert OptimizationResult.pareto_front to ParetoPoint-compatible dicts."""
+    points = []
+    for p in pareto_front:
+        objs = p.get("objectives", {})
+        points.append(
+            {
+                "power": objs.get("power_watts"),
+                "latency": objs.get("latency_ms"),
+                "cost": objs.get("cost_usd"),
+                "area": objs.get("area_mm2"),
+                "hardware": f"custom-{objs.get('process_nm', '?')}nm",
+                "dominated": False,
+                "metadata": p,
+            }
+        )
+    return points
+
+
+def _find_knee_point_index(
+    pareto_front: list[dict[str, Any]],
+    knee_point: dict[str, Any] | None,
+) -> int | None:
+    """Find the index of the knee point in the Pareto front."""
+    if not knee_point or not pareto_front:
+        return None
+    for i, p in enumerate(pareto_front):
+        if p == knee_point:
+            return i
+    return 0 if pareto_front else None
+
+
 def moo_explorer(task: TaskNode, state: SoCDesignState) -> dict[str, Any]:
     """Specialist agent: multi-objective design space exploration.
 
@@ -86,6 +118,11 @@ def moo_explorer(task: TaskNode, state: SoCDesignState) -> dict[str, Any]:
     # Build rich moo_results
     moo_results = result.model_dump()
 
+    # Convert Pareto front to ParetoPoint-compatible dicts for API/snapshot
+    pareto_points = _pareto_front_to_points(result.pareto_front)
+    knee_index = _find_knee_point_index(result.pareto_front, result.knee_point)
+    pareto_results["knee_point_index"] = knee_index
+
     # Summary
     n_front = len(result.pareto_front)
     knee_info = ""
@@ -109,6 +146,7 @@ def moo_explorer(task: TaskNode, state: SoCDesignState) -> dict[str, Any]:
         "pareto_results": pareto_results,
         "moo_results": moo_results,
         "_state_updates": {
+            "pareto_points": pareto_points,
             "pareto_results": pareto_results,
             "moo_results": moo_results,
         },
@@ -187,6 +225,11 @@ def swap_explorer(task: TaskNode, state: SoCDesignState) -> dict[str, Any]:
     pareto_results = result.to_pareto_results()
     moo_results = result.model_dump()
 
+    # Convert Pareto front to ParetoPoint-compatible dicts for API/snapshot
+    pareto_points = _pareto_front_to_points(result.pareto_front)
+    knee_index = _find_knee_point_index(result.pareto_front, result.knee_point)
+    pareto_results["knee_point_index"] = knee_index
+
     # Extract BOM from knee point
     system_bom = {}
     if result.knee_point:
@@ -218,6 +261,7 @@ def swap_explorer(task: TaskNode, state: SoCDesignState) -> dict[str, Any]:
         "swap_results": moo_results,
         "system_bom": system_bom,
         "_state_updates": {
+            "pareto_points": pareto_points,
             "pareto_results": pareto_results,
             "moo_results": moo_results,
             "swap_assessment": moo_results,

--- a/src/embodied_ai_architect/graphs/optimization_review.py
+++ b/src/embodied_ai_architect/graphs/optimization_review.py
@@ -413,15 +413,19 @@ def build_optimization_review_snapshot(
     pareto_points = state.get("pareto_points", [])
     pareto_results = state.get("pareto_results", {})
 
-    # MOO data
+    # MOO data (moo_results is OptimizationResult.model_dump())
     moo_results = state.get("moo_results", {})
     moo_summary = {}
     if moo_results:
+        # Derive convergence metric from convergence_history (last entry's hypervolume)
+        conv_history = moo_results.get("convergence_history", [])
+        convergence_metric = conv_history[-1].get("hypervolume") if conv_history else None
         moo_summary = {
             "total_evaluations": moo_results.get("total_evaluations", 0),
-            "pareto_size": moo_results.get("pareto_size", 0),
+            "pareto_size": len(moo_results.get("pareto_front", [])),
             "hypervolume": moo_results.get("hypervolume"),
-            "convergence_metric": moo_results.get("convergence_metric"),
+            "convergence_metric": convergence_metric,
+            "layers_used": moo_results.get("layers_used", []),
         }
 
     return OptimizationReviewSnapshot(


### PR DESCRIPTION
## Summary
- Wire `pareto_points` from MOO explorer specialists into `SoCDesignState`, enabling the optimization review snapshot and `/api/sessions/{id}/pareto` endpoint to return real Pareto frontier data
- Fix field name mismatches in `build_optimization_review_snapshot()` that caused `moo_summary` to always be empty (`pareto_size` → `len(pareto_front)`, `convergence_metric` → derived from `convergence_history`)
- Fix type mismatch in pareto API endpoint where `front` field expected `list[int]` but received `list[dict]`

## Changes
- `graphs/moo/specialist.py` — Add `_pareto_front_to_points()` and `_find_knee_point_index()` helpers; write `pareto_points` and `knee_point_index` to `_state_updates` in both `moo_explorer` and `swap_explorer`
- `graphs/optimization_review.py` — Fix `moo_summary` to read correct field names from `OptimizationResult.model_dump()`
- `api/server.py` — Compute `front` indices from non-dominated points instead of passing through raw `pareto_results["front"]`

## Test Results
| Target | Result |
|--------|--------|
| test_api_server | 38/38 PASS |
| test_optimization_review | 18/18 PASS |
| test_moo_engine | 13/13 PASS |
| test_pareto | 12/12 PASS |
| test_moo_evaluator | 9/9 PASS |
| black + ruff | PASS |

## Test plan
- [x] Fast CI passes
- [x] Run MOO → check snapshot has populated pareto fields
- [x] Check `/api/sessions/{id}/pareto` returns populated data
- [x] Promote to ready when satisfied: `gh pr ready`

Resolves #21

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Pareto front computation to derive non-dominated points from individual domination flags rather than precomputed results.
  * Enhanced multi-objective optimization API responses to include `pareto_points` and `knee_point_index` for better front visualization.
  * Updated snapshot calculations to derive `pareto_size`, `convergence_metric`, and include `layers_used` for more accurate optimization summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->