### PR TITLE
feat(sensors): SensorRegistry with TF-IDF keyword matching

### DIFF
--- a/src/embodied_ai_architect/cli/commands/sensor.py
+++ b/src/embodied_ai_architect/cli/commands/sensor.py
@@ -42,27 +42,27 @@ def sensor_list(ctx, modality):
     if json_output:
         click.echo(
             json.dumps(
-                [{"id": s.id, "name": s.name, "modality": s.modality} for s in sensors], indent=2
+                [{"id": s.id, "name": s.name, "category": s.category} for s in sensors],
+                indent=2,
             )
         )
         return
 
     if not sensors:
-        msg = "Sensor registry not yet populated."
+        msg = "No sensors found."
         if modality:
             msg += f" (filtered by modality={modality})"
         console.print(f"[yellow]{msg}[/yellow]")
-        console.print("[dim]Sensor definitions will be added in Phase 2.[/dim]")
         return
 
     table = Table(title="Sensors", show_header=True)
     table.add_column("ID", style="cyan")
     table.add_column("Name")
-    table.add_column("Modality")
-    table.add_column("Vendor", style="dim")
+    table.add_column("Category")
+    table.add_column("Type", style="dim")
 
     for s in sensors:
-        table.add_row(s.id, s.name, s.modality, s.vendor)
+        table.add_row(s.id, s.name, s.category, s.sensor_type)
 
     console.print(table)
 
@@ -92,8 +92,8 @@ def sensor_show(ctx, sensor_id):
                 {
                     "id": s.id,
                     "name": s.name,
-                    "modality": s.modality,
-                    "vendor": s.vendor,
+                    "category": s.category,
+                    "sensor_type": s.sensor_type,
                     "description": s.description,
                     "attributes": s.attributes,
                 },
@@ -103,11 +103,13 @@ def sensor_show(ctx, sensor_id):
         return
 
     console.print(f"\n[bold cyan]{s.name}[/bold cyan]  ({s.id})")
-    console.print(f"  Modality: {s.modality}")
-    if s.vendor:
-        console.print(f"  Vendor:   {s.vendor}")
+    console.print(f"  Category:  {s.category}")
+    if s.sensor_type:
+        console.print(f"  Type:      {s.sensor_type}")
     if s.description:
         console.print(f"  {s.description}")
+    if s.aliases:
+        console.print(f"  Aliases:   {', '.join(s.aliases)}")
     if s.attributes:
         console.print("\n  [bold]Attributes[/bold]")
         for k, v in s.attributes.items():
@@ -128,23 +130,32 @@ def sensor_search(ctx, query):
     if json_output:
         click.echo(
             json.dumps(
-                [{"id": s.id, "name": s.name, "modality": s.modality} for s in results], indent=2
+                [
+                    {
+                        "id": r.sensor_id,
+                        "name": r.sensor.name,
+                        "category": r.sensor.category,
+                        "score": r.score,
+                    }
+                    for r in results
+                ],
+                indent=2,
             )
         )
         return
 
     if not results:
         console.print(f"[yellow]No sensors matching '{query}'.[/yellow]")
-        console.print("[dim]Sensor registry not yet populated (Phase 2).[/dim]")
         return
 
     table = Table(title=f"Search: {query}", show_header=True)
     table.add_column("ID", style="cyan")
     table.add_column("Name")
-    table.add_column("Modality")
+    table.add_column("Category")
+    table.add_column("Score", style="green")
 
-    for s in results:
-        table.add_row(s.id, s.name, s.modality)
+    for r in results:
+        table.add_row(r.sensor_id, r.sensor.name, r.sensor.category, f"{r.score:.3f}")
 
     console.print(table)
 

--- a/src/embodied_ai_architect/cli/commands/sensor.py
+++ b/src/embodied_ai_architect/cli/commands/sensor.py
@@ -1,7 +1,7 @@
-"""Sensor browsing CLI commands (issue #54).
+"""Sensor browsing CLI commands (issues #54, #59).
 
-Read-only commands for browsing the sensor registry. Initially backed
-by an empty registry; Phase 2 will populate it.
+Read-only commands for browsing the sensor registry backed by 80+
+sensor YAML definitions with TF-IDF keyword search.
 """
 
 import json
@@ -20,7 +20,7 @@ def sensor():
     \\b
     Examples:
       branes sensor list
-      branes sensor list --modality lidar
+      branes sensor list --category visual
       branes sensor show <sensor_id>
       branes sensor search "stereo camera 30fps"
       branes sensor categories
@@ -29,14 +29,19 @@ def sensor():
 
 
 @sensor.command("list")
-@click.option("--modality", type=str, default=None, help="Filter by modality (camera, lidar, ...)")
+@click.option(
+    "--category",
+    type=str,
+    default=None,
+    help="Filter by category (visual, ranging, inertial, ...)",
+)
 @click.pass_context
-def sensor_list(ctx, modality):
+def sensor_list(ctx, category):
     """List all sensors in the registry."""
     from embodied_ai_architect.sensors import SensorRegistry
 
     registry = SensorRegistry()
-    sensors = registry.list_sensors(modality=modality)
+    sensors = registry.list_sensors(modality=category)
 
     json_output = ctx.obj.get("json", False)
     if json_output:
@@ -50,8 +55,8 @@ def sensor_list(ctx, modality):
 
     if not sensors:
         msg = "No sensors found."
-        if modality:
-            msg += f" (filtered by modality={modality})"
+        if category:
+            msg += f" (filtered by category={category})"
         console.print(f"[yellow]{msg}[/yellow]")
         return
 
@@ -83,7 +88,6 @@ def sensor_show(ctx, sensor_id):
             click.echo(json.dumps({"error": f"Sensor '{sensor_id}' not found"}))
         else:
             console.print(f"[red]Sensor '{sensor_id}' not found.[/red]")
-            console.print("[dim]Sensor registry not yet populated (Phase 2).[/dim]")
         ctx.exit(1)
         return
     if json_output:
@@ -163,7 +167,7 @@ def sensor_search(ctx, query):
 @sensor.command("categories")
 @click.pass_context
 def sensor_categories(ctx):
-    """List sensor modality categories."""
+    """List sensor categories."""
     from embodied_ai_architect.sensors import SensorRegistry
 
     registry = SensorRegistry()
@@ -174,7 +178,7 @@ def sensor_categories(ctx):
         click.echo(json.dumps(cats, indent=2))
         return
 
-    console.print("\n[bold]Sensor Modality Categories[/bold]\n")
+    console.print("\n[bold]Sensor Categories[/bold]\n")
     for cat in cats:
         console.print(f"  {cat}")
     console.print(f"\n[dim]{len(cats)} categories available[/dim]")

--- a/src/embodied_ai_architect/platforms/registry.py
+++ b/src/embodied_ai_architect/platforms/registry.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 
 import logging
 import math
-import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
+
+from embodied_ai_architect.search_utils import bigrams as _bigrams
+from embodied_ai_architect.search_utils import tokenize as _tokenize
 
 logger = logging.getLogger(__name__)
 
@@ -284,129 +286,3 @@ class PlatformRegistry:
     @property
     def data_dir(self) -> Path:
         return self._data_dir
-
-
-_STOP_WORDS = frozenset(
-    {
-        "a",
-        "an",
-        "the",
-        "is",
-        "it",
-        "in",
-        "on",
-        "at",
-        "to",
-        "of",
-        "or",
-        "and",
-        "for",
-        "by",
-        "as",
-        "if",
-        "be",
-        "do",
-        "no",
-        "so",
-        "up",
-        "we",
-        "my",
-        "he",
-        "us",
-        "am",
-        "are",
-        "was",
-        "has",
-        "had",
-        "not",
-        "but",
-        "can",
-        "all",
-        "its",
-        "our",
-        "out",
-        "own",
-        "say",
-        "she",
-        "too",
-        "use",
-        "her",
-        "him",
-        "his",
-        "how",
-        "man",
-        "new",
-        "now",
-        "old",
-        "see",
-        "way",
-        "who",
-        "did",
-        "get",
-        "let",
-        "may",
-        "run",
-        "set",
-        "try",
-        "via",
-        "with",
-        "from",
-        "that",
-        "this",
-        "they",
-        "been",
-        "have",
-        "each",
-        "make",
-        "like",
-        "just",
-        "over",
-        "such",
-        "take",
-        "than",
-        "them",
-        "very",
-        "some",
-        "what",
-        "when",
-        "will",
-        "more",
-        "also",
-        "into",
-        "only",
-        "come",
-        "made",
-        "find",
-        "here",
-        "know",
-        "look",
-        "many",
-        "then",
-        "well",
-        "back",
-        "been",
-        "much",
-        "must",
-        "need",
-        "next",
-    }
-)
-
-
-def _tokenize(text: str) -> list[str]:
-    """Split text into lowercase word tokens, filtering stop words."""
-    return [
-        w
-        for w in re.findall(r"[a-z0-9]+(?:[-_][a-z0-9]+)*", text.lower())
-        if len(w) > 1 and w not in _STOP_WORDS
-    ]
-
-
-def _bigrams(tokens: list[str]) -> list[str]:
-    """Generate space-joined bigrams from token list."""
-    return [f"{tokens[i]} {tokens[i + 1]}" for i in range(len(tokens) - 1)]
-
-
-def _trigrams(tokens: list[str]) -> list[str]:
-    """Generate space-joined trigrams from token list."""
-    return [f"{tokens[i]} {tokens[i + 1]} {tokens[i + 2]}" for i in range(len(tokens) - 2)]

--- a/src/embodied_ai_architect/search_utils.py
+++ b/src/embodied_ai_architect/search_utils.py
@@ -1,0 +1,152 @@
+"""Shared search utilities for TF-IDF keyword matching.
+
+Used by both the platform and sensor registries to tokenize text,
+generate n-grams, and filter stop words consistently.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Shared stop-words — union of platform and sensor registry sets.
+STOP_WORDS = frozenset(
+    {
+        "a",
+        "am",
+        "an",
+        "and",
+        "any",
+        "are",
+        "as",
+        "at",
+        "back",
+        "be",
+        "been",
+        "being",
+        "both",
+        "but",
+        "by",
+        "can",
+        "come",
+        "could",
+        "did",
+        "do",
+        "each",
+        "find",
+        "for",
+        "from",
+        "get",
+        "had",
+        "has",
+        "have",
+        "he",
+        "her",
+        "here",
+        "him",
+        "his",
+        "how",
+        "if",
+        "in",
+        "into",
+        "is",
+        "it",
+        "its",
+        "just",
+        "know",
+        "let",
+        "like",
+        "look",
+        "made",
+        "make",
+        "man",
+        "many",
+        "may",
+        "more",
+        "most",
+        "much",
+        "must",
+        "my",
+        "need",
+        "new",
+        "next",
+        "no",
+        "not",
+        "now",
+        "of",
+        "old",
+        "on",
+        "one",
+        "only",
+        "or",
+        "other",
+        "our",
+        "out",
+        "over",
+        "own",
+        "run",
+        "say",
+        "see",
+        "set",
+        "she",
+        "should",
+        "so",
+        "some",
+        "such",
+        "take",
+        "than",
+        "that",
+        "the",
+        "them",
+        "then",
+        "these",
+        "they",
+        "this",
+        "those",
+        "to",
+        "too",
+        "try",
+        "two",
+        "up",
+        "us",
+        "use",
+        "very",
+        "via",
+        "was",
+        "way",
+        "we",
+        "well",
+        "were",
+        "what",
+        "when",
+        "which",
+        "who",
+        "will",
+        "with",
+        "would",
+        "about",
+        "also",
+        "all",
+    }
+)
+
+
+def tokenize(text: str) -> list[str]:
+    """Split text into lowercase word tokens, filtering stop words.
+
+    Handles hyphenated and underscore-joined compound words as single tokens.
+    """
+    return [
+        w
+        for w in re.findall(r"[a-z0-9]+(?:[-_][a-z0-9]+)*", text.lower())
+        if len(w) > 1 and w not in STOP_WORDS
+    ]
+
+
+def bigrams(tokens: list[str]) -> list[str]:
+    """Generate space-joined bigrams from token list."""
+    return [f"{tokens[i]} {tokens[i + 1]}" for i in range(len(tokens) - 1)]
+
+
+def trigrams(tokens: list[str]) -> list[str]:
+    """Generate space-joined trigrams from token list."""
+    return [f"{tokens[i]} {tokens[i + 1]} {tokens[i + 2]}" for i in range(len(tokens) - 2)]

--- a/src/embodied_ai_architect/sensors/__init__.py
+++ b/src/embodied_ai_architect/sensors/__init__.py
@@ -1,15 +1,19 @@
-"""Sensor registry and browsing (issue #54).
+"""Sensor registry with TF-IDF keyword matching (issues #54, #59).
 
-Stub package — the registry returns empty until Phase 2 populates it
-with sensor definitions from the embodied-schemas catalog.
+Loads 80+ sensor definitions from data/sensors/ and provides ranked
+search for the `branes sensor` CLI and qualification pipeline.
 
 Usage:
     from embodied_ai_architect.sensors import SensorRegistry
 
     registry = SensorRegistry()
-    sensors = registry.list_sensors()  # [] until populated
+    results = registry.search("stereo camera for VIO")
 """
 
-from embodied_ai_architect.sensors.registry import SensorRegistry
+from embodied_ai_architect.sensors.registry import (
+    SensorDefinition,
+    SensorMatchResult,
+    SensorRegistry,
+)
 
-__all__ = ["SensorRegistry"]
+__all__ = ["SensorDefinition", "SensorMatchResult", "SensorRegistry"]

--- a/src/embodied_ai_architect/sensors/registry.py
+++ b/src/embodied_ai_architect/sensors/registry.py
@@ -1,19 +1,35 @@
-"""Sensor registry (issue #54).
+"""Sensor registry with TF-IDF keyword matching (issue #59).
 
-Stub implementation that returns empty results. Phase 2 will populate
-this from the embodied-schemas SensorEntry catalog and/or local YAML
-definitions (mirroring the platform registry pattern).
+Loads sensor YAML files from data/sensors/, builds an inverted keyword
+index, and provides ranked TF-IDF-style search. Mirrors the
+PlatformRegistry pattern from platforms/registry.py.
+
+Usage:
+    from embodied_ai_architect.sensors import SensorRegistry
+
+    registry = SensorRegistry()
+    results = registry.search("stereo camera for VIO", top_k=5)
+    for r in results:
+        print(r.sensor_id, r.score, r.sensor.name)
 """
 
 from __future__ import annotations
 
+import logging
+import math
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 
-# Sensor modality categories — matches data/sensors/taxonomy.yaml top-level
-# keys. Phase 2 will load these dynamically from the YAML; for now they're
-# kept in sync manually (CodeRabbit PR #107).
+logger = logging.getLogger(__name__)
+
+# Default data directory — resolved relative to the repo root
+_DEFAULT_DATA_DIR = Path(__file__).resolve().parent.parent.parent.parent / "data" / "sensors"
+
+# Modality categories from taxonomy.yaml
 MODALITIES = [
     "visual",
     "ranging",
@@ -25,56 +41,310 @@ MODALITIES = [
     "biological",
 ]
 
+# Shared stop-words (same set as platforms/registry.py)
+_STOP_WORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "at",
+        "be",
+        "by",
+        "for",
+        "from",
+        "has",
+        "have",
+        "in",
+        "is",
+        "it",
+        "its",
+        "of",
+        "on",
+        "or",
+        "that",
+        "the",
+        "to",
+        "was",
+        "were",
+        "will",
+        "with",
+        "not",
+        "but",
+        "can",
+        "do",
+        "if",
+        "no",
+        "so",
+        "up",
+        "out",
+        "all",
+        "one",
+        "two",
+        "our",
+        "new",
+        "use",
+        "also",
+        "than",
+        "very",
+        "just",
+        "about",
+        "into",
+        "over",
+        "such",
+        "only",
+        "other",
+        "some",
+        "may",
+        "each",
+        "any",
+        "most",
+        "more",
+        "both",
+        "which",
+        "their",
+        "these",
+        "this",
+        "those",
+        "been",
+        "being",
+        "would",
+        "could",
+        "should",
+    }
+)
+
+
+def _tokenize(text: str) -> list[str]:
+    """Split text into lowercased tokens, filtering stop words."""
+    words = re.findall(r"[a-z0-9]+", text.lower())
+    return [w for w in words if len(w) > 1 and w not in _STOP_WORDS]
+
+
+def _bigrams(tokens: list[str]) -> list[str]:
+    """Generate bigrams from a token list."""
+    return [f"{tokens[i]} {tokens[i + 1]}" for i in range(len(tokens) - 1)]
+
 
 class SensorDefinition(BaseModel):
-    """A sensor in the registry."""
+    """A sensor loaded from the registry."""
 
     id: str
     name: str
-    modality: str
-    vendor: str = ""
+    category: str = ""
+    sensor_type: str = ""
     description: str = ""
+    aliases: list[str] = Field(default_factory=list)
+    keywords: dict[str, list[str]] = Field(default_factory=dict)
+    classification: dict[str, Any] = Field(default_factory=dict)
     attributes: dict[str, Any] = Field(default_factory=dict)
+    reference_products: list[dict[str, Any]] = Field(default_factory=list)
+    raw: dict[str, Any] = Field(default_factory=dict)
+
+    def all_keywords(self) -> list[str]:
+        """Flatten all keyword groups into a single list."""
+        result: list[str] = []
+        for group in self.keywords.values():
+            if isinstance(group, list):
+                result.extend(group)
+        return result
+
+
+@dataclass
+class SensorMatchResult:
+    """A scored match from the sensor registry search."""
+
+    sensor_id: str
+    score: float
+    sensor: SensorDefinition
+    matched_keywords: list[str] = field(default_factory=list)
+
+    def __repr__(self) -> str:
+        return f"SensorMatchResult({self.sensor_id!r}, score={self.score:.3f})"
 
 
 class SensorRegistry:
-    """Stub sensor registry (Phase 1 — returns empty results).
+    """Sensor registry with TF-IDF keyword matching.
 
-    Phase 2 will load sensor definitions from:
-    - embodied-schemas SensorEntry catalog (if installed)
-    - Local YAML files in data/sensors/
+    Loads sensor YAML files from data/sensors/<category>/*.yaml,
+    builds an inverted keyword index, and provides ranked search.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, data_dir: Path | str | None = None):
+        self._data_dir = Path(data_dir) if data_dir else _DEFAULT_DATA_DIR
         self._sensors: dict[str, SensorDefinition] = {}
+        self._keyword_index: dict[str, set[str]] = {}
+        self._idf: dict[str, float] = {}
+        self._loaded = False
 
-    def list_sensors(self, modality: Optional[str] = None) -> list[SensorDefinition]:
-        """List all sensors, optionally filtered by modality."""
-        sensors = list(self._sensors.values())
-        if modality:
-            sensors = [s for s in sensors if s.modality == modality]
-        return sensors
+    def load(self) -> None:
+        """Load all sensor YAML files from the data directory."""
+        import yaml
+
+        self._sensors.clear()
+        self._keyword_index.clear()
+
+        if not self._data_dir.exists():
+            logger.warning("Sensor data directory not found: %s", self._data_dir)
+            self._loaded = True
+            return
+
+        yaml_files = [
+            f
+            for f in self._data_dir.rglob("*.yaml")
+            if f.name not in ("schema.yaml", "taxonomy.yaml") and not f.name.startswith("_")
+        ]
+
+        for fpath in yaml_files:
+            try:
+                with open(fpath, encoding="utf-8") as fh:
+                    data = yaml.safe_load(fh)
+                if not data or "id" not in data:
+                    continue
+                sensor = SensorDefinition(
+                    id=data["id"],
+                    name=data.get("name", data["id"]),
+                    category=data.get("category", ""),
+                    sensor_type=data.get("sensor_type", ""),
+                    description=data.get("description", ""),
+                    aliases=data.get("aliases", []),
+                    keywords=data.get("keywords", {}),
+                    classification=data.get("classification", {}),
+                    attributes=data.get("attributes", {}),
+                    reference_products=data.get("reference_products", []),
+                    raw=data,
+                )
+                self._sensors[sensor.id] = sensor
+            except Exception:
+                logger.warning("Failed to load sensor file: %s", fpath, exc_info=True)
+
+        self._build_index()
+        self._loaded = True
+        logger.info("Loaded %d sensors from %s", len(self._sensors), self._data_dir)
+
+    def _ensure_loaded(self) -> None:
+        if not self._loaded:
+            self.load()
+
+    def _build_index(self) -> None:
+        """Build inverted keyword index and compute IDF values."""
+        self._keyword_index.clear()
+        self._idf.clear()
+
+        for sid, sensor in self._sensors.items():
+            seen: set[str] = set()
+            for kw in sensor.all_keywords():
+                kw_lower = kw.lower().strip()
+                if not kw_lower or kw_lower in seen:
+                    continue
+                seen.add(kw_lower)
+                self._keyword_index.setdefault(kw_lower, set()).add(sid)
+
+            for text in [sensor.name, sensor.description]:
+                for word in _tokenize(text):
+                    self._keyword_index.setdefault(word, set()).add(sid)
+
+        n = max(len(self._sensors), 1)
+        for kw, sids in self._keyword_index.items():
+            self._idf[kw] = math.log(n / len(sids)) + 1.0
+
+    def search(
+        self,
+        query: str,
+        top_k: int = 10,
+        min_score: float = 0.01,
+    ) -> list[SensorMatchResult]:
+        """Search for sensors matching a free-text query.
+
+        TF-IDF scoring with phrase, token, and bigram matching.
+        Returns ranked list, best first.
+        """
+        self._ensure_loaded()
+
+        if top_k <= 0 or not self._sensors:
+            return []
+
+        query_lower = query.lower().strip()
+        query_tokens = _tokenize(query_lower)
+        query_bigrams = _bigrams(query_tokens)
+
+        scores: dict[str, float] = {}
+        matched_kws: dict[str, list[str]] = {}
+
+        # Phase 1: phrase matching
+        for kw_phrase, sids in self._keyword_index.items():
+            if kw_phrase in query_lower:
+                weight = self._idf.get(kw_phrase, 1.0)
+                word_count = len(kw_phrase.split())
+                phrase_bonus = 1.0 + (word_count - 1) * 0.5
+                for sid in sids:
+                    scores[sid] = scores.get(sid, 0.0) + weight * phrase_bonus
+                    matched_kws.setdefault(sid, []).append(kw_phrase)
+
+        # Phase 2: token matching
+        for token in query_tokens:
+            if token in self._keyword_index:
+                weight = self._idf.get(token, 1.0) * 0.5
+                for sid in self._keyword_index[token]:
+                    scores[sid] = scores.get(sid, 0.0) + weight
+                    kws = matched_kws.setdefault(sid, [])
+                    if token not in kws:
+                        kws.append(token)
+
+        # Phase 3: bigram matching
+        for bigram in query_bigrams:
+            if bigram in self._keyword_index:
+                weight = self._idf.get(bigram, 1.0) * 0.8
+                for sid in self._keyword_index[bigram]:
+                    scores[sid] = scores.get(sid, 0.0) + weight
+                    kws = matched_kws.setdefault(sid, [])
+                    if bigram not in kws:
+                        kws.append(bigram)
+
+        if not scores:
+            return []
+
+        max_score = max(scores.values())
+        if max_score > 0:
+            scores = {sid: s / max_score for sid, s in scores.items()}
+
+        results = [
+            SensorMatchResult(
+                sensor_id=sid,
+                score=round(score, 4),
+                sensor=self._sensors[sid],
+                matched_keywords=matched_kws.get(sid, []),
+            )
+            for sid, score in scores.items()
+            if score >= min_score
+        ]
+        results.sort(key=lambda r: r.score, reverse=True)
+        return results[:top_k]
 
     def get(self, sensor_id: str) -> Optional[SensorDefinition]:
         """Get a sensor by ID."""
+        self._ensure_loaded()
         return self._sensors.get(sensor_id)
 
-    def search(self, query: str, top_k: int = 10) -> list[SensorDefinition]:
-        """Search sensors by keyword. Returns empty until populated."""
-        if top_k <= 0:
-            return []
-        if not self._sensors:
-            return []
-        query_lower = query.lower()
-        scored = []
-        for s in self._sensors.values():
-            text = f"{s.name} {s.description} {s.modality} {s.vendor}".lower()
-            score = sum(1 for word in query_lower.split() if word in text)
-            if score > 0:
-                scored.append((score, s))
-        scored.sort(key=lambda x: x[0], reverse=True)
-        return [s for _, s in scored[:top_k]]
+    def list_sensors(self, modality: Optional[str] = None) -> list[SensorDefinition]:
+        """List all sensors, optionally filtered by category/modality."""
+        self._ensure_loaded()
+        sensors = list(self._sensors.values())
+        if modality:
+            sensors = [s for s in sensors if s.category == modality]
+        return sensors
+
+    def list_by_category(self, category: str) -> list[SensorDefinition]:
+        """List sensors in a specific category."""
+        return self.list_sensors(modality=category)
 
     def categories(self) -> list[str]:
         """List available sensor modality categories."""
         return list(MODALITIES)
+
+    @property
+    def sensor_count(self) -> int:
+        """Total number of loaded sensors."""
+        self._ensure_loaded()
+        return len(self._sensors)

--- a/src/embodied_ai_architect/sensors/registry.py
+++ b/src/embodied_ai_architect/sensors/registry.py
@@ -17,12 +17,14 @@ from __future__ import annotations
 
 import logging
 import math
-import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
 from pydantic import BaseModel, Field
+
+from embodied_ai_architect.search_utils import bigrams as _bigrams
+from embodied_ai_architect.search_utils import tokenize as _tokenize
 
 logger = logging.getLogger(__name__)
 
@@ -40,91 +42,6 @@ MODALITIES = [
     "audio",
     "biological",
 ]
-
-# Shared stop-words (same set as platforms/registry.py)
-_STOP_WORDS = frozenset(
-    {
-        "a",
-        "an",
-        "and",
-        "are",
-        "as",
-        "at",
-        "be",
-        "by",
-        "for",
-        "from",
-        "has",
-        "have",
-        "in",
-        "is",
-        "it",
-        "its",
-        "of",
-        "on",
-        "or",
-        "that",
-        "the",
-        "to",
-        "was",
-        "were",
-        "will",
-        "with",
-        "not",
-        "but",
-        "can",
-        "do",
-        "if",
-        "no",
-        "so",
-        "up",
-        "out",
-        "all",
-        "one",
-        "two",
-        "our",
-        "new",
-        "use",
-        "also",
-        "than",
-        "very",
-        "just",
-        "about",
-        "into",
-        "over",
-        "such",
-        "only",
-        "other",
-        "some",
-        "may",
-        "each",
-        "any",
-        "most",
-        "more",
-        "both",
-        "which",
-        "their",
-        "these",
-        "this",
-        "those",
-        "been",
-        "being",
-        "would",
-        "could",
-        "should",
-    }
-)
-
-
-def _tokenize(text: str) -> list[str]:
-    """Split text into lowercased tokens, filtering stop words."""
-    words = re.findall(r"[a-z0-9]+", text.lower())
-    return [w for w in words if len(w) > 1 and w not in _STOP_WORDS]
-
-
-def _bigrams(tokens: list[str]) -> list[str]:
-    """Generate bigrams from a token list."""
-    return [f"{tokens[i]} {tokens[i + 1]}" for i in range(len(tokens) - 1)]
 
 
 class SensorDefinition(BaseModel):
@@ -272,8 +189,10 @@ class SensorRegistry:
         scores: dict[str, float] = {}
         matched_kws: dict[str, list[str]] = {}
 
-        # Phase 1: phrase matching
+        # Phase 1: phrase matching (multi-token keys only to avoid double-counting)
         for kw_phrase, sids in self._keyword_index.items():
+            if " " not in kw_phrase:
+                continue
             if kw_phrase in query_lower:
                 weight = self._idf.get(kw_phrase, 1.0)
                 word_count = len(kw_phrase.split())
@@ -339,9 +258,13 @@ class SensorRegistry:
         """List sensors in a specific category."""
         return self.list_sensors(modality=category)
 
-    def categories(self) -> list[str]:
+    def list_categories(self) -> list[str]:
         """List available sensor modality categories."""
         return list(MODALITIES)
+
+    def categories(self) -> list[str]:
+        """List available sensor modality categories."""
+        return self.list_categories()
 
     @property
     def sensor_count(self) -> int:

--- a/tests/test_sensor_cli.py
+++ b/tests/test_sensor_cli.py
@@ -1,24 +1,35 @@
-"""Tests for the branes sensor CLI command group (issue #54)."""
+"""Tests for the branes sensor CLI command group (issues #54, #59)."""
 
 from click.testing import CliRunner
 
 from embodied_ai_architect.cli.commands.sensor import sensor
-from embodied_ai_architect.sensors.registry import SensorRegistry
 
 
 class TestSensorList:
-    def test_empty_registry(self):
+    def test_lists_sensors(self):
         runner = CliRunner()
         result = runner.invoke(sensor, ["list"], obj={})
         assert result.exit_code == 0
-        assert "not yet populated" in result.output
+        assert "Sensors" in result.output
 
     def test_with_modality_filter(self):
         runner = CliRunner()
         result = runner.invoke(sensor, ["list", "--modality", "ranging"], obj={})
         assert result.exit_code == 0
-        assert "not yet populated" in result.output
         assert "ranging" in result.output
+
+    def test_nonexistent_modality_empty(self):
+        runner = CliRunner()
+        result = runner.invoke(sensor, ["list", "--modality", "nonexistent"], obj={})
+        assert result.exit_code == 0
+        assert "No sensors found" in result.output
+
+    def test_json_output(self):
+        runner = CliRunner()
+        result = runner.invoke(sensor, ["list"], obj={"json": True})
+        assert result.exit_code == 0
+        assert '"id"' in result.output
+        assert '"name"' in result.output
 
 
 class TestSensorShow:
@@ -28,13 +39,45 @@ class TestSensorShow:
         assert result.exit_code != 0
         assert "not found" in result.output
 
+    def test_show_known_sensor(self):
+        runner = CliRunner()
+        result = runner.invoke(sensor, ["show", "visual.rgb_camera"], obj={})
+        assert result.exit_code == 0
+        assert "RGB Camera" in result.output
+
+    def test_show_json(self):
+        runner = CliRunner()
+        result = runner.invoke(sensor, ["show", "visual.rgb_camera"], obj={"json": True})
+        assert result.exit_code == 0
+        assert '"id"' in result.output
+        assert "visual.rgb_camera" in result.output
+
+    def test_not_found_json(self):
+        runner = CliRunner()
+        result = runner.invoke(sensor, ["show", "nonexistent_id"], obj={"json": True})
+        assert result.exit_code != 0
+        assert '"error"' in result.output
+
 
 class TestSensorSearch:
-    def test_empty_results(self):
+    def test_search_finds_results(self):
         runner = CliRunner()
         result = runner.invoke(sensor, ["search", "stereo camera"], obj={})
         assert result.exit_code == 0
+        assert "stereo" in result.output.lower()
+
+    def test_search_no_results(self):
+        runner = CliRunner()
+        result = runner.invoke(sensor, ["search", "qqzzxx"], obj={})
+        assert result.exit_code == 0
         assert "No sensors matching" in result.output
+
+    def test_search_json(self):
+        runner = CliRunner()
+        result = runner.invoke(sensor, ["search", "lidar"], obj={"json": True})
+        assert result.exit_code == 0
+        assert '"id"' in result.output
+        assert '"score"' in result.output
 
 
 class TestSensorCategories:
@@ -47,23 +90,8 @@ class TestSensorCategories:
         assert "inertial" in result.output
         assert "audio" in result.output
 
-
-class TestSensorRegistry:
-    def test_empty_by_default(self):
-        registry = SensorRegistry()
-        assert registry.list_sensors() == []
-
-    def test_categories_not_empty(self):
-        registry = SensorRegistry()
-        cats = registry.categories()
-        assert len(cats) == 8  # matches taxonomy.yaml top-level categories
-        assert "visual" in cats
-        assert "ranging" in cats
-
-    def test_search_empty(self):
-        registry = SensorRegistry()
-        assert registry.search("anything") == []
-
-    def test_get_returns_none(self):
-        registry = SensorRegistry()
-        assert registry.get("nonexistent") is None
+    def test_categories_json(self):
+        runner = CliRunner()
+        result = runner.invoke(sensor, ["categories"], obj={"json": True})
+        assert result.exit_code == 0
+        assert '"visual"' in result.output

--- a/tests/test_sensor_cli.py
+++ b/tests/test_sensor_cli.py
@@ -12,15 +12,15 @@ class TestSensorList:
         assert result.exit_code == 0
         assert "Sensors" in result.output
 
-    def test_with_modality_filter(self):
+    def test_with_category_filter(self):
         runner = CliRunner()
-        result = runner.invoke(sensor, ["list", "--modality", "ranging"], obj={})
+        result = runner.invoke(sensor, ["list", "--category", "ranging"], obj={})
         assert result.exit_code == 0
         assert "ranging" in result.output
 
-    def test_nonexistent_modality_empty(self):
+    def test_nonexistent_category_empty(self):
         runner = CliRunner()
-        result = runner.invoke(sensor, ["list", "--modality", "nonexistent"], obj={})
+        result = runner.invoke(sensor, ["list", "--category", "nonexistent"], obj={})
         assert result.exit_code == 0
         assert "No sensors found" in result.output
 

--- a/tests/test_sensor_registry.py
+++ b/tests/test_sensor_registry.py
@@ -1,0 +1,149 @@
+"""Tests for the SensorRegistry with TF-IDF matching (issue #59)."""
+
+from embodied_ai_architect.sensors import SensorDefinition, SensorMatchResult, SensorRegistry
+
+
+class TestSensorRegistryLoad:
+    """Loading 80 sensor YAML definitions."""
+
+    def test_loads_all_sensors(self):
+        registry = SensorRegistry()
+        registry.load()
+        assert registry.sensor_count >= 80
+
+    def test_auto_loads_on_first_access(self):
+        registry = SensorRegistry()
+        # sensor_count triggers _ensure_loaded
+        assert registry.sensor_count >= 80
+
+    def test_all_categories_represented(self):
+        registry = SensorRegistry()
+        categories = {s.category for s in registry.list_sensors()}
+        for cat in [
+            "visual",
+            "ranging",
+            "inertial",
+            "position",
+            "environmental",
+            "force",
+            "audio",
+            "biological",
+        ]:
+            assert cat in categories, f"Category '{cat}' not represented"
+
+    def test_get_known_sensor(self):
+        registry = SensorRegistry()
+        sensor = registry.get("visual.rgb_camera")
+        assert sensor is not None
+        assert sensor.name == "RGB Camera"
+        assert sensor.category == "visual"
+
+    def test_get_nonexistent_returns_none(self):
+        registry = SensorRegistry()
+        assert registry.get("nonexistent.sensor") is None
+
+    def test_list_by_category(self):
+        registry = SensorRegistry()
+        visual = registry.list_by_category("visual")
+        assert len(visual) >= 10
+        assert all(s.category == "visual" for s in visual)
+
+    def test_list_sensors_with_modality_filter(self):
+        registry = SensorRegistry()
+        ranging = registry.list_sensors(modality="ranging")
+        assert len(ranging) >= 5
+        assert all(s.category == "ranging" for s in ranging)
+
+
+class TestSensorRegistrySearch:
+    """TF-IDF search returns ranked results."""
+
+    def test_stereo_camera_for_vio(self):
+        """The headline acceptance criterion from the issue."""
+        registry = SensorRegistry()
+        results = registry.search("stereo camera for VIO", top_k=5)
+        assert len(results) >= 1
+        # Stereo camera should be in top 3
+        top_ids = [r.sensor_id for r in results[:3]]
+        assert "visual.stereo_camera" in top_ids
+
+    def test_lidar_for_autonomous_driving(self):
+        registry = SensorRegistry()
+        results = registry.search("lidar for autonomous driving")
+        assert len(results) >= 1
+        # A 3D LiDAR should rank high
+        top_types = [r.sensor.sensor_type for r in results[:3]]
+        assert any("lidar" in t for t in top_types)
+
+    def test_imu_for_drone(self):
+        registry = SensorRegistry()
+        results = registry.search("IMU for drone navigation")
+        assert len(results) >= 1
+        top_ids = [r.sensor_id for r in results[:3]]
+        assert any("imu" in sid for sid in top_ids)
+
+    def test_empty_query_returns_empty(self):
+        registry = SensorRegistry()
+        results = registry.search("")
+        assert results == []
+
+    def test_top_k_limits_results(self):
+        registry = SensorRegistry()
+        results = registry.search("camera", top_k=3)
+        assert len(results) <= 3
+
+    def test_top_k_zero_returns_empty(self):
+        registry = SensorRegistry()
+        assert registry.search("camera", top_k=0) == []
+
+    def test_results_are_sorted_by_score(self):
+        registry = SensorRegistry()
+        results = registry.search("thermal infrared camera")
+        if len(results) >= 2:
+            scores = [r.score for r in results]
+            assert scores == sorted(scores, reverse=True)
+
+    def test_match_result_has_matched_keywords(self):
+        registry = SensorRegistry()
+        results = registry.search("stereo camera depth")
+        if results:
+            assert len(results[0].matched_keywords) >= 1
+
+    def test_search_returns_sensor_match_result(self):
+        registry = SensorRegistry()
+        results = registry.search("GPS RTK")
+        if results:
+            assert isinstance(results[0], SensorMatchResult)
+            assert isinstance(results[0].sensor, SensorDefinition)
+            assert results[0].score > 0
+
+
+class TestSensorDefinition:
+    """The sensor model loaded from YAML."""
+
+    def test_all_keywords_flattens(self):
+        sensor = SensorDefinition(
+            id="test.sensor",
+            name="Test",
+            keywords={
+                "identity": ["test sensor", "ts"],
+                "application": ["testing", "validation"],
+            },
+        )
+        kws = sensor.all_keywords()
+        assert "test sensor" in kws
+        assert "ts" in kws
+        assert "testing" in kws
+        assert len(kws) == 4
+
+    def test_sensor_with_reference_products(self):
+        registry = SensorRegistry()
+        sensor = registry.get("visual.stereo_camera")
+        if sensor:
+            assert isinstance(sensor.reference_products, list)
+            # The stereo_camera YAML has Intel RealSense and Stereolabs
+            if sensor.reference_products:
+                assert any(
+                    "stereolabs" in str(p).lower() or "intel" in str(p).lower()
+                    for p in sensor.reference_products
+                )


### PR DESCRIPTION
## Summary
- Replace empty sensor registry stub with full TF-IDF implementation loading 80+ sensor YAML definitions
- Ranked search with phrase matching (1.0× IDF × phrase bonus), bigram matching (0.8× IDF), and token matching (0.5× IDF)
- Update CLI `branes sensor` commands to use `SensorMatchResult` attributes correctly (search scores, category instead of modality)
- 31 tests covering registry loading, all 8 categories, TF-IDF search ranking, and CLI command integration

## Changes
- `src/embodied_ai_architect/sensors/registry.py` — Full `SensorRegistry` with lazy loading, inverted keyword index, IDF computation, and 3-phase search (phrase → token → bigram)
- `src/embodied_ai_architect/sensors/__init__.py` — Export `SensorDefinition`, `SensorMatchResult`, `SensorRegistry`
- `src/embodied_ai_architect/cli/commands/sensor.py` — Fix attribute references for populated registry (`s.category` not `s.modality`, `r.sensor_id`/`r.sensor.name` for search results)
- `tests/test_sensor_registry.py` — 18 new tests for registry loading, category coverage, TF-IDF search ranking, and model validation
- `tests/test_sensor_cli.py` — Updated from empty-registry expectations to populated-registry assertions with JSON output tests

## Test Results
| Suite | Result |
|-------|--------|
| test_sensor_registry.py (18 tests) | PASS |
| test_sensor_cli.py (13 tests) | PASS |
| Full suite (1483 tests) | PASS (21 errors from missing onnxscript — pre-existing) |

## Test plan
- [x] Fast CI passes
- [ ] CodeRabbit review addressed
- [ ] Promote to ready: `gh pr ready`

Resolves #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Populated sensor registry with 80+ real sensor definitions and TF‑IDF ranked search
  * Search now returns relevance scores and more detailed match info

* **Improvements**
  * UI/CLI labels replaced: "Category"/"Type" instead of "Modality"/"Vendor"; CLI accepts category filtering
  * Sensor details show aliases and richer fields; JSON/table outputs updated
  * Shared, centralized text tokenization used for search

* **Tests**
  * Expanded end-to-end and registry tests covering loading, listing, search, and JSON outputs

* **Bug Fixes**
  * Removed empty/placeholder registry messaging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->