### PR TITLE
refactor(design): wire qualify and plan to read/write Mission entity

### DIFF
--- a/src/embodied_ai_architect/cli/commands/design.py
+++ b/src/embodied_ai_architect/cli/commands/design.py
@@ -681,7 +681,6 @@ def design_plan(
 
         mission.design_state = state
         mission.status = MissionStatus.DESIGNED
-        mission.touch()
         store.save(mission)
         console.print(f"[green]Mission '{mission.name}' updated → designed[/green]")
 
@@ -920,7 +919,6 @@ def design_qualify(ctx, goal, mission_id, domain, auto):
             if inputs.get("system_spec"):
                 mission.spec = inputs["system_spec"]
             mission.status = MissionStatus.QUALIFIED
-            mission.touch()
             store.save(mission)
             console.print(f"\n[green]Mission '{mission.name}' updated → qualified[/green]")
             console.print(f"[dim]Next: branes design plan --mission {mission.id}[/dim]")
@@ -932,7 +930,6 @@ def design_qualify(ctx, goal, mission_id, domain, auto):
         # Still save partial results to mission if present
         if mission and store:
             mission.goal = goal
-            mission.touch()
             store.save(mission)
 
 

--- a/src/embodied_ai_architect/cli/commands/design.py
+++ b/src/embodied_ai_architect/cli/commands/design.py
@@ -483,7 +483,8 @@ def _save_pipeline(config: dict, path: Path) -> None:
 
 
 @design.command("plan")
-@click.argument("goal")
+@click.argument("goal", required=False, default=None)
+@click.option("--mission", "mission_id", help="Load goal/constraints from a mission")
 @click.option("--power", type=float, help="Max power budget in watts")
 @click.option("--latency", type=float, help="Max latency in ms")
 @click.option("--cost", type=float, help="Max BOM cost in USD")
@@ -493,7 +494,9 @@ def _save_pipeline(config: dict, path: Path) -> None:
 @click.option("--platform", default="", help="Platform type (e.g., drone, amr, quadruped)")
 @click.option("--static", is_flag=True, help="Use static demo plan instead of LLM")
 @click.pass_context
-def design_plan(ctx, goal, power, latency, cost, area, process, use_case, platform, static):
+def design_plan(
+    ctx, goal, mission_id, power, latency, cost, area, process, use_case, platform, static
+):
     """Show the task plan the LLM generates for a design goal.
 
     Runs the planner to decompose a natural-language goal into a task graph
@@ -503,7 +506,7 @@ def design_plan(ctx, goal, power, latency, cost, area, process, use_case, platfo
     \\b
     Examples:
       branes design plan "Drone perception SoC: YOLO at 30fps, <5W, <\\$30"
-      branes design plan "Robot arm vision: <10ms latency" --power 15 --latency 10
+      branes design plan --mission vineyard-sprayer
       branes design plan "Drone SoC" --static   # no API key needed
     """
     from embodied_ai_architect.graphs.soc_state import (
@@ -516,6 +519,46 @@ def design_plan(ctx, goal, power, latency, cost, area, process, use_case, platfo
         render_plan_review_rich,
     )
     from embodied_ai_architect.graphs.specialists import create_default_dispatcher
+
+    # Load mission if specified
+    mission = None
+    if mission_id:
+        from embodied_ai_architect.mission.store import MissionStore
+
+        store = MissionStore()
+        mission = store.load(mission_id)
+        if not mission:
+            console.print(f"[red]Mission '{mission_id}' not found.[/red]")
+            ctx.exit(1)
+            return
+        if not goal:
+            goal = mission.goal
+        if not goal:
+            console.print("[red]Mission has no goal. Set one with 'branes mission edit'.[/red]")
+            ctx.exit(1)
+            return
+        # Pull constraints from mission if not overridden by flags
+        mc = mission.constraints
+        if power is None and mc.get("max_power_watts") is not None:
+            power = mc["max_power_watts"]
+        if latency is None and mc.get("max_latency_ms") is not None:
+            latency = mc["max_latency_ms"]
+        if cost is None and mc.get("max_cost_usd") is not None:
+            cost = mc["max_cost_usd"]
+        if area is None and mc.get("max_area_mm2") is not None:
+            area = mc["max_area_mm2"]
+        if process is None and mc.get("target_process_nm") is not None:
+            process = mc["target_process_nm"]
+        if not use_case and mission.use_case:
+            use_case = mission.use_case
+        if not platform and mission.platform_id:
+            platform = mission.platform_id
+        console.print(f"[dim]Loaded mission: {mission.name} ({mission.id})[/dim]")
+
+    if not goal:
+        console.print("[red]Goal is required. Provide a goal argument or --mission.[/red]")
+        ctx.exit(1)
+        return
 
     # Build constraints
     constraint_kwargs = {}
@@ -632,6 +675,16 @@ def design_plan(ctx, goal, power, latency, cost, area, process, use_case, platfo
 
     state = {**state, **plan_updates}
 
+    # Save plan to mission if we loaded one
+    if mission:
+        from embodied_ai_architect.mission.models import MissionStatus
+
+        mission.design_state = state
+        mission.status = MissionStatus.DESIGNED
+        mission.touch()
+        store.save(mission)
+        console.print(f"[green]Mission '{mission.name}' updated → designed[/green]")
+
     # Display the plan review
     dispatcher = create_default_dispatcher()
     available_agents = dispatcher.registered_agents
@@ -675,7 +728,8 @@ def design_plan(ctx, goal, power, latency, cost, area, process, use_case, platfo
 
 
 @design.command("qualify")
-@click.argument("goal")
+@click.argument("goal", required=False, default=None)
+@click.option("--mission", "mission_id", help="Read/write a mission entity")
 @click.option("--domain", "-d", help="Force a domain (drone, ugv, robot_arm)")
 @click.option(
     "--auto",
@@ -683,7 +737,7 @@ def design_plan(ctx, goal, power, latency, cost, area, process, use_case, platfo
     help="Auto-answer with defaults where possible (non-interactive)",
 )
 @click.pass_context
-def design_qualify(ctx, goal, domain, auto):
+def design_qualify(ctx, goal, mission_id, domain, auto):
     """Qualify a design goal through structured Q&A.
 
     Checks whether a goal is specific enough to produce meaningful design
@@ -692,11 +746,44 @@ def design_qualify(ctx, goal, domain, auto):
     \\b
     Examples:
       branes design qualify "drone perception SoC"
+      branes design qualify --mission vineyard-sprayer
       branes design qualify "cobot for assembly" --domain robot_arm
       branes design qualify "warehouse AMR" --auto
     """
     from embodied_ai_architect.qualification import GoalQualifier
     from embodied_ai_architect.qualification.qualifier import render_qualification_result
+
+    # Load or create mission if --mission is specified
+    mission = None
+    store = None
+    if mission_id:
+        from embodied_ai_architect.mission.models import Mission, MissionStatus
+        from embodied_ai_architect.mission.store import MissionStore
+
+        store = MissionStore()
+        mission = store.load(mission_id)
+        if not mission:
+            # Create new mission with this ID
+            mission = Mission(id=mission_id, name=mission_id)
+            if goal:
+                mission.goal = goal
+            store.save(mission)
+            console.print(f"[green]Created mission '{mission_id}'[/green]")
+        else:
+            console.print(f"[dim]Loaded mission: {mission.name} ({mission.id})[/dim]")
+        if not goal:
+            goal = mission.goal
+        if not goal:
+            console.print(
+                "[red]Goal is required. Provide a goal argument or set it on the mission.[/red]"
+            )
+            ctx.exit(1)
+            return
+
+    if not goal:
+        console.print("[red]Goal is required. Provide a goal argument or --mission.[/red]")
+        ctx.exit(1)
+        return
 
     qualifier = GoalQualifier()
     result = qualifier.assess(goal, domain=domain)
@@ -818,11 +905,35 @@ def design_qualify(ctx, goal, domain, auto):
 
     if result.is_tangible:
         _show_design_inputs(qualifier)
+        # Save qualification results to mission
+        if mission and store:
+            from embodied_ai_architect.mission.models import MissionStatus
+
+            inputs = qualifier.to_design_inputs()
+            mission.goal = inputs.get("goal", goal)
+            mission.platform_id = inputs.get("platform") or None
+            mission.use_case = inputs.get("use_case") or None
+            if inputs.get("constraints"):
+                mission.constraints = inputs["constraints"].model_dump(
+                    exclude_none=True, exclude_defaults=True
+                )
+            if inputs.get("system_spec"):
+                mission.spec = inputs["system_spec"]
+            mission.status = MissionStatus.QUALIFIED
+            mission.touch()
+            store.save(mission)
+            console.print(f"\n[green]Mission '{mission.name}' updated → qualified[/green]")
+            console.print(f"[dim]Next: branes design plan --mission {mission.id}[/dim]")
     else:
         console.print("[yellow]Goal could not be fully qualified.[/yellow]")
         console.print(
             "[dim]Missing: " + ", ".join(result.qualification.missing_dimensions) + "[/dim]"
         )
+        # Still save partial results to mission if present
+        if mission and store:
+            mission.goal = goal
+            mission.touch()
+            store.save(mission)
 
 
 def _show_platform_context(qualifier, console) -> None:

--- a/tests/test_design_mission_wire.py
+++ b/tests/test_design_mission_wire.py
@@ -1,0 +1,165 @@
+"""Tests for design qualify/plan --mission wiring (issue #64)."""
+
+import pytest
+from click.testing import CliRunner
+
+from embodied_ai_architect.cli.commands.design import design
+from embodied_ai_architect.mission.models import Mission, MissionStatus
+from embodied_ai_architect.mission.store import MissionStore
+
+
+@pytest.fixture()
+def mission_store(tmp_path, monkeypatch):
+    """Provide a MissionStore in a temp directory."""
+    monkeypatch.chdir(tmp_path)
+    return MissionStore()
+
+
+@pytest.fixture()
+def draft_mission(mission_store):
+    """Create a draft mission with a goal."""
+    m = Mission(
+        id="test-drone",
+        name="Test Drone",
+        goal="Drone perception SoC for YOLO at 30fps under 5W",
+        constraints={"max_power_watts": 5.0, "max_latency_ms": 33.0},
+        use_case="delivery_drone",
+        platform_id="drone",
+    )
+    mission_store.save(m)
+    return m
+
+
+@pytest.fixture()
+def qualified_mission(mission_store):
+    """Create a qualified mission ready for planning."""
+    m = Mission(
+        id="test-qualified",
+        name="Test Qualified",
+        goal="Drone perception SoC for YOLO at 30fps under 5W",
+        status=MissionStatus.QUALIFIED,
+        constraints={"max_power_watts": 5.0, "max_latency_ms": 33.0},
+        use_case="delivery_drone",
+        platform_id="drone",
+    )
+    mission_store.save(m)
+    return m
+
+
+class TestDesignQualifyMission:
+    def test_qualify_creates_new_mission(self, mission_store):
+        """--mission with new ID creates the mission."""
+        runner = CliRunner()
+        result = runner.invoke(
+            design,
+            ["qualify", "drone perception SoC", "--mission", "new-mission", "--auto"],
+            obj={},
+            input="\n" * 50,  # auto-skip all interactive prompts
+        )
+        assert result.exit_code == 0
+        assert "Created mission" in result.output
+        loaded = mission_store.load("new-mission")
+        assert loaded is not None
+        assert loaded.goal  # goal should be populated
+
+    def test_qualify_loads_existing_mission(self, mission_store, draft_mission):
+        """--mission with existing ID loads the mission's goal."""
+        runner = CliRunner()
+        result = runner.invoke(
+            design,
+            ["qualify", "--mission", draft_mission.id, "--auto"],
+            obj={},
+            input="\n" * 50,
+        )
+        assert result.exit_code == 0
+        assert "Loaded mission" in result.output
+
+    def test_qualify_no_goal_no_mission_fails(self, mission_store):
+        """Must provide either goal argument or --mission."""
+        runner = CliRunner()
+        result = runner.invoke(design, ["qualify"], obj={})
+        assert result.exit_code != 0
+        assert "Goal is required" in result.output
+
+    def test_qualify_backward_compat_no_mission(self):
+        """Old form without --mission still works."""
+        runner = CliRunner()
+        result = runner.invoke(
+            design,
+            ["qualify", "drone perception SoC", "--auto"],
+            obj={},
+            input="\n" * 50,
+        )
+        assert result.exit_code == 0
+        # Should show qualification result (no mission created)
+        assert "Tangibility" in result.output or "Design Qualification" in result.output
+
+
+class TestDesignPlanMission:
+    def test_plan_loads_from_mission(self, mission_store, qualified_mission):
+        """--mission loads goal and constraints from mission."""
+        runner = CliRunner()
+        result = runner.invoke(
+            design,
+            ["plan", "--mission", qualified_mission.id, "--static"],
+            obj={},
+        )
+        assert result.exit_code == 0
+        assert "Loaded mission" in result.output
+        # Plan should be saved back
+        loaded = mission_store.load(qualified_mission.id)
+        assert loaded.status == MissionStatus.DESIGNED
+        assert loaded.design_state is not None
+
+    def test_plan_goal_overrides_mission(self, mission_store, qualified_mission):
+        """Positional goal overrides mission goal."""
+        runner = CliRunner()
+        result = runner.invoke(
+            design,
+            ["plan", "Custom goal override", "--mission", qualified_mission.id, "--static"],
+            obj={},
+        )
+        assert result.exit_code == 0
+        # Should still load mission for constraints
+        assert "Loaded mission" in result.output
+
+    def test_plan_nonexistent_mission_fails(self, mission_store):
+        """--mission with bad ID fails."""
+        runner = CliRunner()
+        result = runner.invoke(
+            design,
+            ["plan", "--mission", "nonexistent", "--static"],
+            obj={},
+        )
+        assert result.exit_code != 0
+        assert "not found" in result.output
+
+    def test_plan_no_goal_no_mission_fails(self, mission_store):
+        """Must provide goal or --mission."""
+        runner = CliRunner()
+        result = runner.invoke(design, ["plan", "--static"], obj={})
+        assert result.exit_code != 0
+        assert "Goal is required" in result.output
+
+    def test_plan_backward_compat_no_mission(self):
+        """Old form with positional goal still works."""
+        runner = CliRunner()
+        result = runner.invoke(
+            design,
+            ["plan", "Drone perception SoC", "--static"],
+            obj={},
+        )
+        assert result.exit_code == 0
+        assert "static demo plan" in result.output.lower() or "Task Graph" in result.output
+
+    def test_plan_mission_constraints_applied(self, mission_store, qualified_mission):
+        """Constraints from mission are used when flags not provided."""
+        runner = CliRunner()
+        result = runner.invoke(
+            design,
+            ["plan", "--mission", qualified_mission.id, "--static"],
+            obj={},
+        )
+        assert result.exit_code == 0
+        loaded = mission_store.load(qualified_mission.id)
+        assert loaded.design_state is not None

--- a/tests/test_design_mission_wire.py
+++ b/tests/test_design_mission_wire.py
@@ -163,3 +163,9 @@ class TestDesignPlanMission:
         assert result.exit_code == 0
         loaded = mission_store.load(qualified_mission.id)
         assert loaded.design_state is not None
+        # Verify mission constraints were propagated into the design state
+        ds = loaded.design_state
+        if ds.get("constraints"):
+            c = ds["constraints"]
+            assert c.get("max_power_watts") == qualified_mission.constraints["max_power_watts"]
+            assert c.get("max_latency_ms") == qualified_mission.constraints["max_latency_ms"]


### PR DESCRIPTION
## Summary
- Add `--mission` flag to `design qualify` and `design plan` commands
- `qualify --mission X` creates/loads mission, saves qualification results (goal, platform, constraints, spec), transitions to QUALIFIED
- `plan --mission X` loads goal/constraints from mission, saves design_state, transitions to DESIGNED
- Old positional-argument forms continue to work (backward compatible)

## Usage
```bash
# New mission-aware workflow
branes design qualify "vineyard sprayer" --mission vineyard-sprayer --auto
branes design plan --mission vineyard-sprayer --static

# Old one-shot workflow still works
branes design qualify "drone perception SoC" --auto
branes design plan "drone perception SoC" --power 5 --latency 33 --static
```

## Changes
- `src/embodied_ai_architect/cli/commands/design.py` — `--mission` option on qualify and plan, mission load/save logic
- `tests/test_design_mission_wire.py` — 10 new tests

## Test plan
- [ ] Fast CI passes
- [ ] CodeRabbit review addressed

Resolves #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `design plan` and `design qualify` commands now support an optional `--mission` flag to load mission details (goal, constraints, platform, use case) for the workflow.
  * Design and qualification results are automatically saved back to missions, updating their status accordingly.
  * Goal argument is now optional when using `--mission`; missions can be created or loaded during the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->