### PR TITLE
refactor(spec): migrate spec to be backed by mission state

### DIFF
--- a/src/embodied_ai_architect/cli/commands/spec.py
+++ b/src/embodied_ai_architect/cli/commands/spec.py
@@ -73,6 +73,11 @@ def spec_new(ctx, name: str, template: str | None, description: str | None):
 
         spec_obj = store.create(name, template=template, description=description)
 
+        # Sync to mission
+        from embodied_ai_architect.specs.mission_bridge import sync_spec_to_mission
+
+        sync_spec_to_mission(name, spec_obj.model_dump(exclude_none=True, mode="json"))
+
         if json_output:
             click.echo(json.dumps(spec_obj.model_dump(exclude_none=True, mode="json"), indent=2))
         else:
@@ -211,6 +216,11 @@ def spec_set(ctx, name: str, path: str, value: str, message: str | None, author:
             parsed_value = value
 
         spec_obj = store.set_field(name, path, parsed_value, author=author, reason=message)
+
+        # Sync to mission
+        from embodied_ai_architect.specs.mission_bridge import sync_spec_to_mission
+
+        sync_spec_to_mission(name, spec_obj.model_dump(exclude_none=True, mode="json"))
 
         if json_output:
             click.echo(json.dumps(spec_obj.model_dump(exclude_none=True, mode="json"), indent=2))
@@ -490,6 +500,11 @@ def spec_import(ctx, name: str, file_path: str, author: str):
             data = json.loads(path.read_text())
 
         spec_obj = store.import_spec(name, data, author=author, reason=f"Imported from {path.name}")
+
+        # Sync to mission
+        from embodied_ai_architect.specs.mission_bridge import sync_spec_to_mission
+
+        sync_spec_to_mission(name, spec_obj.model_dump(exclude_none=True, mode="json"))
 
         if json_output:
             click.echo(json.dumps(spec_obj.model_dump(exclude_none=True, mode="json"), indent=2))

--- a/src/embodied_ai_architect/cli/commands/spec.py
+++ b/src/embodied_ai_architect/cli/commands/spec.py
@@ -258,6 +258,12 @@ def spec_delete(ctx, name: str, path: str, message: str | None, author: str):
         store = SpecStore()
         store.delete_field(name, path, author=author, reason=message)
 
+        # Sync to mission (re-read full spec after deletion)
+        spec_obj = store.get(name)
+        from embodied_ai_architect.specs.mission_bridge import sync_spec_to_mission
+
+        sync_spec_to_mission(name, spec_obj.model_dump(exclude_none=True, mode="json"))
+
         if json_output:
             click.echo(json.dumps({"status": "ok", "path": path}))
         else:

--- a/src/embodied_ai_architect/specs/mission_bridge.py
+++ b/src/embodied_ai_architect/specs/mission_bridge.py
@@ -1,0 +1,125 @@
+"""Bridge between SpecStore and MissionStore (issue #66).
+
+When a spec is created or modified, the bridge syncs the spec data
+into the corresponding Mission's `spec` field. This keeps the spec's
+event-sourced versioning intact while connecting specs to missions.
+
+The bridge creates a Mission for each spec (using the spec name as
+the mission ID) and keeps `mission.spec` in sync with the spec state.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def sync_spec_to_mission(spec_name: str, spec_data: dict[str, Any]) -> None:
+    """Sync a spec's current state to its corresponding Mission.
+
+    Creates the mission if it doesn't exist. Updates mission.spec with
+    the full spec data (model_dump output from SystemSpec).
+    """
+    try:
+        from embodied_ai_architect.mission.models import Mission
+        from embodied_ai_architect.mission.store import MissionStore
+
+        store = MissionStore()
+        mission = store.load(spec_name)
+
+        if not mission:
+            mission = Mission(
+                id=spec_name,
+                name=spec_name,
+                description=spec_data.get("description", ""),
+                goal=spec_data.get("description", ""),
+            )
+
+        mission.spec = spec_data
+
+        # Extract constraints from spec if present
+        _sync_constraints(mission, spec_data)
+
+        store.save(mission)
+        logger.debug("Synced spec '%s' to mission", spec_name)
+    except Exception:
+        # Sync is best-effort — never block spec operations
+        logger.debug("Failed to sync spec to mission", exc_info=True)
+
+
+def _sync_constraints(mission: Any, spec_data: dict[str, Any]) -> None:
+    """Extract constraint-like fields from spec into mission.constraints."""
+    constraints: dict[str, Any] = dict(mission.constraints or {})
+
+    # Power constraints
+    power = spec_data.get("power") or {}
+    if isinstance(power, dict):
+        if power.get("power_budget_watts") is not None:
+            constraints["max_power_watts"] = power["power_budget_watts"]
+        if power.get("compute_power_watts") is not None:
+            constraints.setdefault("max_power_watts", power["compute_power_watts"])
+
+    # Perception latency
+    perception = spec_data.get("perception") or {}
+    if isinstance(perception, dict):
+        if perception.get("max_latency_ms") is not None:
+            constraints["max_latency_ms"] = perception["max_latency_ms"]
+
+    # Compute constraints
+    compute = spec_data.get("compute") or {}
+    if isinstance(compute, dict):
+        if compute.get("max_tdp_watts") is not None:
+            constraints.setdefault("max_power_watts", compute["max_tdp_watts"])
+
+    if constraints:
+        mission.constraints = constraints
+
+
+def load_spec_from_mission(mission_id: str) -> Optional[dict[str, Any]]:
+    """Load a spec from a Mission's spec field.
+
+    Returns the spec dict or None if the mission doesn't exist
+    or has no spec data.
+    """
+    try:
+        from embodied_ai_architect.mission.store import MissionStore
+
+        store = MissionStore()
+        mission = store.load(mission_id)
+        if mission and mission.spec:
+            return mission.spec
+    except Exception:
+        logger.debug("Failed to load spec from mission", exc_info=True)
+    return None
+
+
+def migrate_specs_to_missions() -> list[str]:
+    """Auto-migrate all existing specs to missions.
+
+    For each spec in SpecStore that doesn't have a corresponding mission,
+    create one and sync the spec data.
+
+    Returns list of migrated spec names.
+    """
+    try:
+        from embodied_ai_architect.specs.store import SpecStore
+
+        spec_store = SpecStore()
+        specs = spec_store.list_specs()
+        migrated = []
+
+        for name in specs.get("specs", {}):
+            try:
+                spec_obj = spec_store.get(name)
+                spec_data = spec_obj.model_dump(exclude_none=True, mode="json")
+                sync_spec_to_mission(name, spec_data)
+                migrated.append(name)
+            except Exception:
+                logger.warning("Failed to migrate spec '%s' to mission", name, exc_info=True)
+
+        return migrated
+    except Exception:
+        logger.debug("Failed to migrate specs", exc_info=True)
+        return []

--- a/src/embodied_ai_architect/specs/mission_bridge.py
+++ b/src/embodied_ai_architect/specs/mission_bridge.py
@@ -15,12 +15,17 @@ from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
+# Keys managed by constraint extraction — cleared on each sync to avoid stale values
+_MANAGED_CONSTRAINT_KEYS = {"max_power_watts", "max_latency_ms"}
 
-def sync_spec_to_mission(spec_name: str, spec_data: dict[str, Any]) -> None:
+
+def sync_spec_to_mission(spec_name: str, spec_data: dict[str, Any]) -> bool:
     """Sync a spec's current state to its corresponding Mission.
 
     Creates the mission if it doesn't exist. Updates mission.spec with
     the full spec data (model_dump output from SystemSpec).
+
+    Returns True on success, False on failure.
     """
     try:
         from embodied_ai_architect.mission.models import Mission
@@ -44,22 +49,37 @@ def sync_spec_to_mission(spec_name: str, spec_data: dict[str, Any]) -> None:
 
         store.save(mission)
         logger.debug("Synced spec '%s' to mission", spec_name)
+        return True
     except Exception:
         # Sync is best-effort — never block spec operations
         logger.debug("Failed to sync spec to mission", exc_info=True)
+        return False
 
 
 def _sync_constraints(mission: Any, spec_data: dict[str, Any]) -> None:
-    """Extract constraint-like fields from spec into mission.constraints."""
-    constraints: dict[str, Any] = dict(mission.constraints or {})
+    """Extract constraint-like fields from spec into mission.constraints.
+
+    Clears managed keys first so deleted spec fields don't leave stale
+    constraint values.
+    """
+    # Preserve non-managed keys, clear managed ones
+    constraints: dict[str, Any] = {
+        k: v for k, v in (mission.constraints or {}).items() if k not in _MANAGED_CONSTRAINT_KEYS
+    }
 
     # Power constraints
     power = spec_data.get("power") or {}
     if isinstance(power, dict):
         if power.get("power_budget_watts") is not None:
             constraints["max_power_watts"] = power["power_budget_watts"]
-        if power.get("compute_power_watts") is not None:
-            constraints.setdefault("max_power_watts", power["compute_power_watts"])
+        elif power.get("compute_power_watts") is not None:
+            constraints["max_power_watts"] = power["compute_power_watts"]
+
+    # Compute constraints (fallback for power)
+    compute = spec_data.get("compute") or {}
+    if isinstance(compute, dict):
+        if "max_power_watts" not in constraints and compute.get("max_tdp_watts") is not None:
+            constraints["max_power_watts"] = compute["max_tdp_watts"]
 
     # Perception latency
     perception = spec_data.get("perception") or {}
@@ -67,14 +87,7 @@ def _sync_constraints(mission: Any, spec_data: dict[str, Any]) -> None:
         if perception.get("max_latency_ms") is not None:
             constraints["max_latency_ms"] = perception["max_latency_ms"]
 
-    # Compute constraints
-    compute = spec_data.get("compute") or {}
-    if isinstance(compute, dict):
-        if compute.get("max_tdp_watts") is not None:
-            constraints.setdefault("max_power_watts", compute["max_tdp_watts"])
-
-    if constraints:
-        mission.constraints = constraints
+    mission.constraints = constraints
 
 
 def load_spec_from_mission(mission_id: str) -> Optional[dict[str, Any]]:
@@ -101,21 +114,22 @@ def migrate_specs_to_missions() -> list[str]:
     For each spec in SpecStore that doesn't have a corresponding mission,
     create one and sync the spec data.
 
-    Returns list of migrated spec names.
+    Returns list of successfully migrated spec names.
     """
     try:
         from embodied_ai_architect.specs.store import SpecStore
 
         spec_store = SpecStore()
-        specs = spec_store.list_specs()
+        index = spec_store.list_specs()
+        spec_names = list(index.get("specs", {}).keys()) if isinstance(index, dict) else []
         migrated = []
 
-        for name in specs.get("specs", {}):
+        for name in spec_names:
             try:
                 spec_obj = spec_store.get(name)
                 spec_data = spec_obj.model_dump(exclude_none=True, mode="json")
-                sync_spec_to_mission(name, spec_data)
-                migrated.append(name)
+                if sync_spec_to_mission(name, spec_data):
+                    migrated.append(name)
             except Exception:
                 logger.warning("Failed to migrate spec '%s' to mission", name, exc_info=True)
 

--- a/tests/test_spec_mission_bridge.py
+++ b/tests/test_spec_mission_bridge.py
@@ -1,0 +1,105 @@
+"""Tests for spec-to-mission bridge (issue #66)."""
+
+import pytest
+from click.testing import CliRunner
+
+from embodied_ai_architect.cli.commands.spec import spec
+from embodied_ai_architect.mission.store import MissionStore
+from embodied_ai_architect.specs.mission_bridge import (
+    load_spec_from_mission,
+    sync_spec_to_mission,
+)
+
+
+@pytest.fixture()
+def working_dir(tmp_path, monkeypatch):
+    """Set working directory to tmp_path for both SpecStore and MissionStore."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+class TestSyncSpecToMission:
+    def test_creates_mission(self, working_dir):
+        sync_spec_to_mission("test-spec", {"name": "test-spec", "description": "A test"})
+        store = MissionStore()
+        mission = store.load("test-spec")
+        assert mission is not None
+        assert mission.spec["name"] == "test-spec"
+
+    def test_updates_existing_mission(self, working_dir):
+        sync_spec_to_mission("test-spec", {"name": "test-spec", "description": "v1"})
+        sync_spec_to_mission("test-spec", {"name": "test-spec", "description": "v2"})
+        store = MissionStore()
+        mission = store.load("test-spec")
+        assert mission.spec["description"] == "v2"
+
+    def test_extracts_power_constraint(self, working_dir):
+        sync_spec_to_mission(
+            "power-spec",
+            {"name": "power-spec", "power": {"power_budget_watts": 5.0}},
+        )
+        store = MissionStore()
+        mission = store.load("power-spec")
+        assert mission.constraints.get("max_power_watts") == 5.0
+
+    def test_extracts_latency_constraint(self, working_dir):
+        sync_spec_to_mission(
+            "latency-spec",
+            {"name": "latency-spec", "perception": {"max_latency_ms": 33.0}},
+        )
+        store = MissionStore()
+        mission = store.load("latency-spec")
+        assert mission.constraints.get("max_latency_ms") == 33.0
+
+
+class TestLoadSpecFromMission:
+    def test_load_existing(self, working_dir):
+        sync_spec_to_mission("my-spec", {"name": "my-spec", "foo": "bar"})
+        data = load_spec_from_mission("my-spec")
+        assert data is not None
+        assert data["name"] == "my-spec"
+
+    def test_load_nonexistent(self, working_dir):
+        data = load_spec_from_mission("nonexistent")
+        assert data is None
+
+
+class TestSpecNewSyncsToMission:
+    def test_spec_new_creates_mission(self, working_dir):
+        runner = CliRunner()
+        result = runner.invoke(spec, ["new", "my-drone"], obj={})
+        assert result.exit_code == 0
+
+        store = MissionStore()
+        mission = store.load("my-drone")
+        assert mission is not None
+        assert mission.spec.get("name") == "my-drone"
+
+    def test_spec_new_with_template_syncs(self, working_dir):
+        runner = CliRunner()
+        result = runner.invoke(
+            spec, ["new", "my-drone-tmpl", "--template", "drone-perception"], obj={}
+        )
+        assert result.exit_code == 0
+
+        store = MissionStore()
+        mission = store.load("my-drone-tmpl")
+        assert mission is not None
+        # Template should populate spec fields
+        assert mission.spec.get("name") == "my-drone-tmpl"
+
+
+class TestSpecSetSyncsToMission:
+    def test_set_syncs(self, working_dir):
+        runner = CliRunner()
+        # First create the spec
+        runner.invoke(spec, ["new", "my-spec"], obj={})
+        # Then set a field
+        result = runner.invoke(spec, ["set", "my-spec", "/perception/min_fps", "60"], obj={})
+        assert result.exit_code == 0
+
+        store = MissionStore()
+        mission = store.load("my-spec")
+        assert mission is not None
+        perception = mission.spec.get("perception") or {}
+        assert perception.get("min_fps") == 60


### PR DESCRIPTION
## Summary
- Add spec-to-mission bridge that syncs spec data to corresponding Mission entities
- When specs are created/modified/imported, the bridge creates/updates a Mission with matching ID
- Extracts power and latency constraints from spec fields into mission.constraints
- Preserves SpecStore's event-sourced versioning intact — additive bridge, not a replacement

## How it works
```
branes spec new my-drone --template drone-perception
  → Creates spec in .branes/specs/my-drone/
  → Also creates Mission "my-drone" with mission.spec = full SystemSpec data
  
branes spec set my-drone /perception/min_fps 60
  → Updates spec via event log
  → Syncs updated spec to mission.spec
```

## Changes
- `src/embodied_ai_architect/specs/mission_bridge.py` — New bridge module with `sync_spec_to_mission()`, `load_spec_from_mission()`, `migrate_specs_to_missions()`
- `src/embodied_ai_architect/cli/commands/spec.py` — Added sync calls in `spec new`, `spec set`, `spec import`
- `tests/test_spec_mission_bridge.py` — 9 tests

## Test plan
- [ ] Fast CI passes
- [ ] All 82 existing spec tests pass (no regression)
- [ ] CodeRabbit review addressed

Resolves #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Specs automatically synchronize with mission storage during creation, updates, and imports via CLI commands.
  * Mission entries are created or updated with corresponding spec data and extracted constraint mappings.

* **Tests**
  * Added comprehensive test coverage for spec-mission synchronization behavior, constraint extraction, and CLI integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->