### PR TITLE
feat(cli): create lifecycle command groups (select/synthesize/analyze)

### DIFF
--- a/src/embodied_ai_architect/cli/__init__.py
+++ b/src/embodied_ai_architect/cli/__init__.py
@@ -80,6 +80,9 @@ def main():
     from embodied_ai_architect.cli.commands import sensor as sensor_cmd
     from embodied_ai_architect.cli.commands import actuator as actuator_cmd
     from embodied_ai_architect.cli.commands import validate as validate_cmd
+    from embodied_ai_architect.cli.commands import select as select_cmd
+    from embodied_ai_architect.cli.commands import synthesize as synthesize_cmd
+    from embodied_ai_architect.cli.commands import analyze_group
 
     # Register command groups
     cli.add_command(workflow.workflow)
@@ -109,6 +112,9 @@ def main():
     cli.add_command(sensor_cmd.sensor)
     cli.add_command(actuator_cmd.actuator)
     cli.add_command(validate_cmd.validate)
+    cli.add_command(select_cmd.select)
+    cli.add_command(synthesize_cmd.synthesize)
+    cli.add_command(analyze_group.analyze_lifecycle, "analyze-system")
 
     # Run CLI
     cli(obj={})

--- a/src/embodied_ai_architect/cli/commands/analyze_group.py
+++ b/src/embodied_ai_architect/cli/commands/analyze_group.py
@@ -1,7 +1,7 @@
 """Lifecycle command group: analyze mission subsystems (issue #67).
 
-Groups analysis commands by subsystem. The original `branes analyze model.pt`
-command is preserved as `branes analyze model model.pt`.
+Groups analysis commands by subsystem. Registered as `branes analyze-system`
+to coexist with the original `branes analyze` model analysis command.
 """
 
 import click

--- a/src/embodied_ai_architect/cli/commands/analyze_group.py
+++ b/src/embodied_ai_architect/cli/commands/analyze_group.py
@@ -1,0 +1,96 @@
+"""Lifecycle command group: analyze mission subsystems (issue #67).
+
+Groups analysis commands by subsystem. The original `branes analyze model.pt`
+command is preserved as `branes analyze model model.pt`.
+"""
+
+import click
+from rich.console import Console
+
+console = Console()
+
+
+@click.group(invoke_without_command=True)
+@click.pass_context
+def analyze_lifecycle(ctx):
+    """Analyze mission subsystems.
+
+    \\b
+    Examples:
+      branes analyze-system power <mission_id>
+      branes analyze-system latency <mission_id>
+      branes analyze-system swap <mission_id>
+      branes analyze-system safety <mission_id>
+    """
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+@analyze_lifecycle.command("power")
+@click.argument("mission_id")
+@click.pass_context
+def analyze_power(ctx, mission_id):
+    """Analyze power budget for a mission."""
+    console.print("[yellow]Coming in a future release.[/yellow]")
+    console.print("[dim]For now, use: branes mcp energy <model> <hardware>[/dim]")
+
+
+@analyze_lifecycle.command("latency")
+@click.argument("mission_id")
+@click.pass_context
+def analyze_latency(ctx, mission_id):
+    """Analyze end-to-end latency for a mission."""
+    console.print("[yellow]Coming in a future release.[/yellow]")
+    console.print("[dim]For now, use: branes mcp latency <model> <hardware>[/dim]")
+
+
+@analyze_lifecycle.command("thermal")
+@click.argument("mission_id")
+@click.pass_context
+def analyze_thermal(ctx, mission_id):
+    """Analyze thermal feasibility for a mission."""
+    console.print("[yellow]Coming in a future release.[/yellow]")
+
+
+@analyze_lifecycle.command("swap")
+@click.argument("mission_id")
+@click.pass_context
+def analyze_swap(ctx, mission_id):
+    """Run SWaP-C analysis for a mission."""
+    console.print("[yellow]Coming in a future release.[/yellow]")
+    console.print("[dim]For now, use: branes swap check --mission <mission>[/dim]")
+
+
+@analyze_lifecycle.command("safety")
+@click.argument("mission_id")
+@click.pass_context
+def analyze_safety(ctx, mission_id):
+    """Analyze safety requirements for a mission."""
+    console.print("[yellow]Coming in a future release.[/yellow]")
+    console.print("[dim]For now, use: branes validate safety <mission>[/dim]")
+
+
+@analyze_lifecycle.command("cost")
+@click.argument("mission_id")
+@click.pass_context
+def analyze_cost(ctx, mission_id):
+    """Analyze cost breakdown for a mission."""
+    console.print("[yellow]Coming in a future release.[/yellow]")
+    console.print("[dim]For now, use: branes swap bom --mission <mission>[/dim]")
+
+
+@analyze_lifecycle.command("bandwidth")
+@click.argument("mission_id")
+@click.pass_context
+def analyze_bandwidth(ctx, mission_id):
+    """Analyze data bandwidth requirements for a mission."""
+    console.print("[yellow]Coming in a future release.[/yellow]")
+
+
+@analyze_lifecycle.command("scheduling")
+@click.argument("mission_id")
+@click.pass_context
+def analyze_scheduling(ctx, mission_id):
+    """Analyze task scheduling feasibility for a mission."""
+    console.print("[yellow]Coming in a future release.[/yellow]")
+    console.print("[dim]For now, use: branes validate scheduling <mission>[/dim]")

--- a/src/embodied_ai_architect/cli/commands/select.py
+++ b/src/embodied_ai_architect/cli/commands/select.py
@@ -1,0 +1,69 @@
+"""Lifecycle command group: select components for a mission (issue #67).
+
+Delegates to existing sensor/actuator/mcp/zoo commands with mission context.
+"""
+
+import click
+from rich.console import Console
+
+console = Console()
+
+
+@click.group()
+def select():
+    """Select components for a mission.
+
+    \\b
+    Examples:
+      branes select sensor <mission_id> <sensor_id>
+      branes select actuator <mission_id> <actuator_id>
+      branes select compute <mission_id>
+      branes select model <mission_id>
+    """
+    pass
+
+
+@select.command("sensor")
+@click.argument("mission_id")
+@click.argument("sensor_ids", nargs=-1, required=True)
+@click.pass_context
+def select_sensor(ctx, mission_id, sensor_ids):
+    """Select sensors for a mission."""
+    from embodied_ai_architect.cli.commands.sensor import sensor_select
+
+    ctx.invoke(sensor_select, mission_id=mission_id, sensor_ids=sensor_ids)
+
+
+@select.command("actuator")
+@click.argument("mission_id")
+@click.argument("actuator_ids", nargs=-1, required=True)
+@click.pass_context
+def select_actuator(ctx, mission_id, actuator_ids):
+    """Select actuators for a mission."""
+    from embodied_ai_architect.cli.commands.actuator import actuator_select
+
+    ctx.invoke(actuator_select, mission_id=mission_id, actuator_ids=actuator_ids)
+
+
+@select.command("compute")
+@click.argument("mission_id")
+@click.pass_context
+def select_compute(ctx, mission_id):
+    """Select compute hardware for a mission.
+
+    Lists available hardware and lets you pick one for the mission.
+    """
+    console.print("[yellow]Coming in a future release.[/yellow]")
+    console.print("[dim]For now, use: branes mcp hardware --query <query>[/dim]")
+
+
+@select.command("model")
+@click.argument("mission_id")
+@click.pass_context
+def select_model(ctx, mission_id):
+    """Select ML models for a mission.
+
+    Recommends models based on mission perception tasks.
+    """
+    console.print("[yellow]Coming in a future release.[/yellow]")
+    console.print("[dim]For now, use: branes zoo list[/dim]")

--- a/src/embodied_ai_architect/cli/commands/synthesize.py
+++ b/src/embodied_ai_architect/cli/commands/synthesize.py
@@ -1,0 +1,156 @@
+"""Lifecycle command group: synthesize system from mission (issue #67).
+
+Commands for composing a full system design from selected components.
+"""
+
+import json
+
+import click
+from rich.console import Console
+
+console = Console()
+
+
+@click.group()
+def synthesize():
+    """Synthesize a system design from mission components.
+
+    \\b
+    Examples:
+      branes synthesize system <mission_id>
+      branes synthesize architecture <mission_id>
+      branes synthesize bom <mission_id>
+    """
+    pass
+
+
+@synthesize.command("system")
+@click.argument("mission_id")
+@click.pass_context
+def synthesize_system(ctx, mission_id):
+    """Compose a full system from mission's selected components.
+
+    Reads selected sensors, actuators, compute, and models from the
+    mission and generates a coherent system specification.
+    """
+    from embodied_ai_architect.mission.store import MissionStore
+
+    store = MissionStore()
+    mission = store.load(mission_id)
+    if not mission:
+        console.print(f"[red]Mission '{mission_id}' not found.[/red]")
+        ctx.exit(1)
+        return
+
+    json_output = ctx.obj.get("json", False)
+    summary = {
+        "mission": mission.name,
+        "sensors": mission.selected_sensors,
+        "actuators": mission.selected_actuators,
+        "compute": mission.selected_compute,
+        "models": mission.selected_models,
+        "constraints": mission.constraints,
+    }
+
+    if json_output:
+        click.echo(json.dumps(summary, indent=2))
+        return
+
+    console.print(f"\n[bold]System Synthesis — {mission.name}[/bold]\n")
+    console.print(f"  Sensors:    {', '.join(mission.selected_sensors) or 'none'}")
+    console.print(f"  Actuators:  {', '.join(mission.selected_actuators) or 'none'}")
+    console.print(f"  Compute:    {mission.selected_compute or 'none'}")
+    console.print(f"  Models:     {', '.join(mission.selected_models) or 'none'}")
+    if mission.constraints:
+        console.print(f"  Constraints: {mission.constraints}")
+    console.print()
+
+    missing = []
+    if not mission.selected_sensors:
+        missing.append("sensors")
+    if not mission.selected_actuators:
+        missing.append("actuators")
+    if not mission.selected_compute:
+        missing.append("compute")
+
+    if missing:
+        console.print(f"[yellow]Missing selections: {', '.join(missing)}[/yellow]")
+        console.print("[dim]Use 'branes select <type> <mission>' to add components.[/dim]")
+    else:
+        console.print("[green]All component types selected. Ready for analysis.[/green]")
+
+
+@synthesize.command("architecture")
+@click.argument("mission_id")
+@click.pass_context
+def synthesize_architecture(ctx, mission_id):
+    """Generate architecture diagram for a mission's system.
+
+    Produces a Mermaid-compatible diagram showing component relationships.
+    """
+    from embodied_ai_architect.mission.store import MissionStore
+
+    store = MissionStore()
+    mission = store.load(mission_id)
+    if not mission:
+        console.print(f"[red]Mission '{mission_id}' not found.[/red]")
+        ctx.exit(1)
+        return
+
+    json_output = ctx.obj.get("json", False)
+
+    # Generate a simple Mermaid diagram from selected components
+    lines = ["graph TD"]
+    lines.append("    SoC[SoC Design]")
+
+    for sid in mission.selected_sensors:
+        safe = sid.replace(".", "_")
+        lines.append(f"    {safe}[{sid}] --> SoC")
+
+    if mission.selected_compute:
+        lines.append(f"    SoC --> Compute[{mission.selected_compute}]")
+
+    for mid in mission.selected_models:
+        safe = mid.replace(".", "_").replace("-", "_")
+        lines.append(f"    Compute --> {safe}[{mid}]")
+
+    for aid in mission.selected_actuators:
+        safe = aid.replace(".", "_")
+        lines.append(f"    SoC --> {safe}[{aid}]")
+
+    mermaid = "\n".join(lines)
+
+    if json_output:
+        click.echo(json.dumps({"mermaid": mermaid}))
+        return
+
+    console.print(f"\n[bold]Architecture — {mission.name}[/bold]\n")
+    console.print("```mermaid")
+    console.print(mermaid)
+    console.print("```")
+    console.print()
+
+
+@synthesize.command("bom")
+@click.argument("mission_id")
+@click.pass_context
+def synthesize_bom(ctx, mission_id):
+    """Generate bill of materials for a mission."""
+    console.print("[yellow]Coming in a future release.[/yellow]")
+    console.print("[dim]For now, use: branes swap bom --mission <mission>[/dim]")
+
+
+@synthesize.command("cabling")
+@click.argument("mission_id")
+@click.pass_context
+def synthesize_cabling(ctx, mission_id):
+    """Generate cabling and interconnect plan."""
+    console.print("[yellow]Coming in a future release.[/yellow]")
+
+
+@synthesize.command("thermal")
+@click.argument("mission_id")
+@click.pass_context
+def synthesize_thermal(ctx, mission_id):
+    """Generate thermal management plan."""
+    console.print("[yellow]Coming in a future release.[/yellow]")

--- a/src/embodied_ai_architect/cli/commands/synthesize.py
+++ b/src/embodied_ai_architect/cli/commands/synthesize.py
@@ -35,14 +35,16 @@ def synthesize_system(ctx, mission_id):
     """
     from embodied_ai_architect.mission.store import MissionStore
 
+    json_output = ctx.obj.get("json", False)
     store = MissionStore()
     mission = store.load(mission_id)
     if not mission:
-        console.print(f"[red]Mission '{mission_id}' not found.[/red]")
+        if json_output:
+            click.echo(json.dumps({"error": f"Mission '{mission_id}' not found"}))
+        else:
+            console.print(f"[red]Mission '{mission_id}' not found.[/red]")
         ctx.exit(1)
         return
-
-    json_output = ctx.obj.get("json", False)
     summary = {
         "mission": mission.name,
         "sensors": mission.selected_sensors,
@@ -90,14 +92,16 @@ def synthesize_architecture(ctx, mission_id):
     """
     from embodied_ai_architect.mission.store import MissionStore
 
+    json_output = ctx.obj.get("json", False)
     store = MissionStore()
     mission = store.load(mission_id)
     if not mission:
-        console.print(f"[red]Mission '{mission_id}' not found.[/red]")
+        if json_output:
+            click.echo(json.dumps({"error": f"Mission '{mission_id}' not found"}))
+        else:
+            console.print(f"[red]Mission '{mission_id}' not found.[/red]")
         ctx.exit(1)
         return
-
-    json_output = ctx.obj.get("json", False)
 
     # Generate a simple Mermaid diagram from selected components
     lines = ["graph TD"]

--- a/tests/test_lifecycle_groups.py
+++ b/tests/test_lifecycle_groups.py
@@ -1,0 +1,112 @@
+"""Tests for lifecycle command groups select/synthesize/analyze-system (#67)."""
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from embodied_ai_architect.cli.commands.analyze_group import analyze_lifecycle
+from embodied_ai_architect.cli.commands.select import select
+from embodied_ai_architect.cli.commands.synthesize import synthesize
+from embodied_ai_architect.mission.models import Mission
+from embodied_ai_architect.mission.store import MissionStore
+
+
+@pytest.fixture()
+def mission(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    store = MissionStore()
+    m = Mission(
+        id="test-mission",
+        name="Test Mission",
+        goal="Drone perception",
+        selected_sensors=["visual.rgb_camera", "inertial.imu_6dof"],
+        selected_actuators=["motor.brushless_dc"],
+        selected_compute="jetson_orin_nano",
+        selected_models=["yolov8n"],
+        constraints={"max_power_watts": 5.0},
+    )
+    store.save(m)
+    return m
+
+
+class TestSelectGroup:
+    def test_select_sensor(self, mission):
+        runner = CliRunner()
+        result = runner.invoke(select, ["sensor", mission.id, "visual.stereo_camera"], obj={})
+        assert result.exit_code == 0
+
+    def test_select_actuator(self, mission):
+        runner = CliRunner()
+        result = runner.invoke(select, ["actuator", mission.id, "motor.servo"], obj={})
+        assert result.exit_code == 0
+
+    def test_select_compute_stub(self):
+        runner = CliRunner()
+        result = runner.invoke(select, ["compute", "any-mission"], obj={})
+        assert result.exit_code == 0
+        assert "Coming in a future release" in result.output
+
+    def test_select_model_stub(self):
+        runner = CliRunner()
+        result = runner.invoke(select, ["model", "any-mission"], obj={})
+        assert result.exit_code == 0
+        assert "Coming in a future release" in result.output
+
+
+class TestSynthesizeGroup:
+    def test_synthesize_system(self, mission):
+        runner = CliRunner()
+        result = runner.invoke(synthesize, ["system", mission.id], obj={})
+        assert result.exit_code == 0
+        assert "System Synthesis" in result.output
+        assert "visual.rgb_camera" in result.output
+
+    def test_synthesize_system_json(self, mission):
+        runner = CliRunner()
+        result = runner.invoke(synthesize, ["system", mission.id], obj={"json": True})
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "sensors" in data
+        assert "visual.rgb_camera" in data["sensors"]
+
+    def test_synthesize_architecture(self, mission):
+        runner = CliRunner()
+        result = runner.invoke(synthesize, ["architecture", mission.id], obj={})
+        assert result.exit_code == 0
+        assert "mermaid" in result.output.lower() or "graph TD" in result.output
+
+    def test_synthesize_bom_stub(self):
+        runner = CliRunner()
+        result = runner.invoke(synthesize, ["bom", "any"], obj={})
+        assert "Coming in a future release" in result.output
+
+    def test_synthesize_nonexistent_mission(self, mission):
+        runner = CliRunner()
+        result = runner.invoke(synthesize, ["system", "nonexistent"], obj={})
+        assert result.exit_code != 0
+        assert "not found" in result.output
+
+
+class TestAnalyzeSystemGroup:
+    def test_power_stub(self):
+        runner = CliRunner()
+        result = runner.invoke(analyze_lifecycle, ["power", "any"], obj={})
+        assert "Coming in a future release" in result.output
+
+    def test_latency_stub(self):
+        runner = CliRunner()
+        result = runner.invoke(analyze_lifecycle, ["latency", "any"], obj={})
+        assert "Coming in a future release" in result.output
+
+    def test_safety_stub(self):
+        runner = CliRunner()
+        result = runner.invoke(analyze_lifecycle, ["safety", "any"], obj={})
+        assert "Coming in a future release" in result.output
+
+    def test_help_shown_without_subcommand(self):
+        runner = CliRunner()
+        result = runner.invoke(analyze_lifecycle, [], obj={})
+        assert result.exit_code == 0
+        assert "power" in result.output
+        assert "latency" in result.output


### PR DESCRIPTION
## Summary
- Add 3 new top-level command groups organizing commands by design lifecycle phase
- `branes select` delegates to existing sensor/actuator select commands
- `branes synthesize` composes systems from mission components (system summary + Mermaid architecture)
- `branes analyze-system` provides stub entry points for future subsystem analysis

## New Commands (17 total)
| Group | Commands |
|-------|----------|
| `select` | sensor, actuator, compute (stub), model (stub) |
| `synthesize` | system, architecture, bom (stub), cabling (stub), thermal (stub) |
| `analyze-system` | power, latency, thermal, swap, safety, cost, bandwidth, scheduling (stubs) |

## Changes
- `src/embodied_ai_architect/cli/commands/select.py` — 4 subcommands
- `src/embodied_ai_architect/cli/commands/synthesize.py` — 5 subcommands
- `src/embodied_ai_architect/cli/commands/analyze_group.py` — 8 subcommands
- `src/embodied_ai_architect/cli/__init__.py` — Register new groups
- `tests/test_lifecycle_groups.py` — 13 tests

## Test plan
- [x] Fast CI passes
- [x] Existing `branes analyze model.pt` still works
- [x] CodeRabbit review addressed

Resolves #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added analyze-system group with lifecycle analysis options (power, latency, thermal, swap, safety, cost, bandwidth, scheduling).
  * Added select group to configure mission components (sensor, actuator, compute, model).
  * Added synthesize group to produce system summaries and architecture visualizations; BOM/cabling/thermal planned.

* **Behavior**
  * Several subcommands currently show “Coming in a future release” and provide alternative guidance.

* **Tests**
  * Added tests covering the new CLI workflows and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->