### PR TITLE
feat(qualify): load matched platform context into LLM system prompt

### DIFF
--- a/src/embodied_ai_architect/cli/commands/chat.py
+++ b/src/embodied_ai_architect/cli/commands/chat.py
@@ -118,6 +118,12 @@ def chat(ctx, model: str, verbose: bool):
                 _show_help()
                 continue
 
+            # Inject platform context into system prompt on first design-related message
+            if not agent._platform_context_prompt:
+                agent.set_platform_context(user_input)
+                if agent._platform_context_prompt and verbose:
+                    console.print("  [dim]Platform context injected into system prompt[/dim]")
+
             # Enrich with platform context on design-related prompts
             enriched_input = _maybe_enrich_with_platform_context(user_input, console, verbose)
 

--- a/src/embodied_ai_architect/cli/commands/chat.py
+++ b/src/embodied_ai_architect/cli/commands/chat.py
@@ -96,6 +96,7 @@ def chat(ctx, model: str, verbose: bool):
     console.print()
 
     # Main loop
+    context_initialized = False
     while True:
         try:
             # Get user input
@@ -118,8 +119,9 @@ def chat(ctx, model: str, verbose: bool):
                 _show_help()
                 continue
 
-            # Inject platform context into system prompt on first design-related message
-            if not agent._platform_context_prompt:
+            # Inject platform context into system prompt once (first message only)
+            if not context_initialized:
+                context_initialized = True
                 agent.set_platform_context(user_input)
                 if agent._platform_context_prompt and verbose:
                     console.print("  [dim]Platform context injected into system prompt[/dim]")

--- a/src/embodied_ai_architect/cli/commands/design.py
+++ b/src/embodied_ai_architect/cli/commands/design.py
@@ -649,27 +649,17 @@ def design_plan(
             return
 
         from embodied_ai_architect.llm.client import LLMClient
-        from embodied_ai_architect.platforms.context import (
-            get_platform_context_for_goal,
-            build_context_prompt,
-        )
 
         llm = LLMClient()
 
-        # Enrich planner prompt with platform registry context
-        platform_ctx = get_platform_context_for_goal(goal)
-        context_prompt = build_context_prompt(platform_ctx)
-        if context_prompt:
-            from embodied_ai_architect.graphs.planner import PLANNER_SYSTEM_PROMPT
-
-            enriched_prompt = PLANNER_SYSTEM_PROMPT + "\n\n" + context_prompt
-            planner = PlannerNode(llm=llm, system_prompt=enriched_prompt)
+        # PlannerNode auto-enriches from state["platform_context"]
+        planner = PlannerNode(llm=llm)
+        if platform_ctx:
             pid = platform_ctx.get("platform_id", "")
             console.print(
                 f"[dim]Platform context loaded: {pid} — " f"calling LLM to decompose goal...[/dim]"
             )
         else:
-            planner = PlannerNode(llm=llm)
             console.print("[dim]Calling LLM to decompose goal into task graph...[/dim]")
 
     try:

--- a/src/embodied_ai_architect/cli/commands/design.py
+++ b/src/embodied_ai_architect/cli/commands/design.py
@@ -575,11 +575,17 @@ def design_plan(
 
     constraints = DesignConstraints(**constraint_kwargs) if constraint_kwargs else None
 
+    # Look up platform context from registry
+    from embodied_ai_architect.platforms.context import get_platform_context_for_goal
+
+    platform_ctx = get_platform_context_for_goal(goal)
+
     state = create_initial_soc_state(
         goal=goal,
         constraints=constraints,
         use_case=use_case,
         platform=platform,
+        platform_context=platform_ctx,
     )
 
     # Create planner

--- a/src/embodied_ai_architect/graphs/planner.py
+++ b/src/embodied_ai_architect/graphs/planner.py
@@ -295,6 +295,15 @@ class PlannerNode:
         platform = state.get("platform", "")
         enable_moo = state.get("enable_moo", True)
 
+        # Enrich LLM prompt with platform context if available in state
+        platform_ctx = state.get("platform_context", {})
+        if platform_ctx and self.static_plan is None:
+            from embodied_ai_architect.platforms.context import build_context_prompt
+
+            ctx_text = build_context_prompt(platform_ctx)
+            if ctx_text:
+                self.system_prompt = self.system_prompt + "\n\n" + ctx_text
+
         if self.static_plan is not None:
             task_dicts = self.static_plan
         else:

--- a/src/embodied_ai_architect/graphs/planner.py
+++ b/src/embodied_ai_architect/graphs/planner.py
@@ -296,18 +296,23 @@ class PlannerNode:
         enable_moo = state.get("enable_moo", True)
 
         # Enrich LLM prompt with platform context if available in state
+        effective_prompt = self.system_prompt
         platform_ctx = state.get("platform_context", {})
         if platform_ctx and self.static_plan is None:
             from embodied_ai_architect.platforms.context import build_context_prompt
 
             ctx_text = build_context_prompt(platform_ctx)
             if ctx_text:
-                self.system_prompt = self.system_prompt + "\n\n" + ctx_text
+                effective_prompt = effective_prompt + "\n\n" + ctx_text
 
         if self.static_plan is not None:
             task_dicts = self.static_plan
         else:
+            # Use effective_prompt (with platform context) for this call only
+            saved = self.system_prompt
+            self.system_prompt = effective_prompt
             task_dicts = self._plan_with_llm(goal, constraints, use_case, platform)
+            self.system_prompt = saved
 
         # Honor enable_moo: strip moo_explorer tasks (and their dependents'
         # references) when the user opted out. The default plans and the LLM

--- a/src/embodied_ai_architect/graphs/soc_state.py
+++ b/src/embodied_ai_architect/graphs/soc_state.py
@@ -253,6 +253,7 @@ class SoCDesignState(TypedDict, total=False):
     constraints: dict  # DesignConstraints serialized (TypedDict requires plain types)
     use_case: str  # "delivery_drone", "warehouse_amr", "surgical_robot", etc.
     platform: str  # "drone", "quadruped", "biped", "amr", "edge"
+    platform_context: dict  # Matched platform context from registry (architecture, pitfalls, etc.)
 
     # === Task Graph ===
     task_graph: dict  # TaskGraph serialized via to_dict()
@@ -341,6 +342,7 @@ def create_initial_soc_state(
     rtl_enabled: bool = False,
     rtl_area_feedback: bool = False,
     enable_moo: bool = True,
+    platform_context: Optional[dict] = None,
 ) -> SoCDesignState:
     """Create initial state for a new SoC design session.
 
@@ -366,6 +368,7 @@ def create_initial_soc_state(
         constraints=constraints.model_dump() if constraints else {},
         use_case=use_case,
         platform=platform,
+        platform_context=platform_context or {},
         # Task Graph
         task_graph=task_graph.to_dict(),
         current_task_id="",

--- a/src/embodied_ai_architect/llm/agent.py
+++ b/src/embodied_ai_architect/llm/agent.py
@@ -163,6 +163,20 @@ class ArchitectAgent:
         self.max_iterations = max_iterations
         self.verbose = verbose
         self.messages: list[dict[str, Any]] = []
+        self._platform_context_prompt: str = ""
+
+    def set_platform_context(self, goal: str) -> None:
+        """Look up platform context for a goal and cache it for prompt injection."""
+        try:
+            from embodied_ai_architect.platforms.context import (
+                build_context_prompt,
+                get_platform_context_for_goal,
+            )
+
+            ctx = get_platform_context_for_goal(goal)
+            self._platform_context_prompt = build_context_prompt(ctx)
+        except Exception:
+            self._platform_context_prompt = ""
 
     def reset(self) -> None:
         """Clear conversation history."""
@@ -199,11 +213,14 @@ class ArchitectAgent:
         while iterations < self.max_iterations:
             iterations += 1
 
-            # Get LLM response
+            # Get LLM response — inject platform context if available
+            system = SYSTEM_PROMPT
+            if self._platform_context_prompt:
+                system = system + "\n\n" + self._platform_context_prompt
             response = self.llm.chat(
                 messages=self.messages,
                 tools=self.tool_definitions,
-                system=SYSTEM_PROMPT,
+                system=system,
             )
 
             # If there's text and we're thinking, emit it

--- a/tests/test_platform_context_injection.py
+++ b/tests/test_platform_context_injection.py
@@ -1,0 +1,92 @@
+"""Tests for platform context injection into LLM prompts (issue #99)."""
+
+from embodied_ai_architect.graphs.soc_state import create_initial_soc_state
+from embodied_ai_architect.platforms.context import (
+    build_context_prompt,
+    get_platform_context_for_goal,
+)
+
+
+class TestPlatformContextInState:
+    def test_state_has_platform_context_field(self):
+        state = create_initial_soc_state(goal="drone perception SoC")
+        assert "platform_context" in state
+
+    def test_state_stores_platform_context(self):
+        ctx = {"platform_id": "test.drone", "context": {"typical_architecture": "ARM SoC"}}
+        state = create_initial_soc_state(goal="drone SoC", platform_context=ctx)
+        assert state["platform_context"]["platform_id"] == "test.drone"
+
+    def test_state_default_empty_context(self):
+        state = create_initial_soc_state(goal="test")
+        assert state["platform_context"] == {}
+
+
+class TestBuildContextPrompt:
+    def test_empty_context(self):
+        assert build_context_prompt({}) == ""
+
+    def test_with_architecture(self):
+        ctx = {
+            "platform_id": "aerial.drone",
+            "platform_name": "Delivery Drone",
+            "platform_description": "A delivery drone",
+            "context": {
+                "typical_architecture": "ARM + NPU",
+                "design_considerations": "Weight matters",
+            },
+        }
+        prompt = build_context_prompt(ctx)
+        assert "Delivery Drone" in prompt
+        assert "ARM + NPU" in prompt
+        assert "Weight matters" in prompt
+
+    def test_with_pitfalls(self):
+        ctx = {
+            "platform_id": "test",
+            "platform_name": "Test",
+            "platform_description": "",
+            "context": {
+                "common_pitfalls": ["Thermal throttling", "Battery sag"],
+            },
+        }
+        prompt = build_context_prompt(ctx)
+        assert "Thermal throttling" in prompt
+
+
+class TestGetPlatformContextForGoal:
+    def test_drone_goal_returns_context(self):
+        ctx = get_platform_context_for_goal("delivery drone for packages")
+        # Should match an aerial platform
+        if ctx:
+            assert "platform_id" in ctx
+            assert "context" in ctx
+
+    def test_nonsense_goal_returns_empty(self):
+        ctx = get_platform_context_for_goal("zzzzxxxx nonsense")
+        assert ctx == {}
+
+
+class TestPlannerContextInjection:
+    def test_planner_enriches_prompt_from_state(self):
+        """PlannerNode should detect platform_context in state."""
+        from embodied_ai_architect.graphs.planner import PlannerNode
+
+        static_plan = [
+            {"id": "t1", "name": "Test", "agent": "workload_analyzer", "dependencies": []},
+        ]
+        planner = PlannerNode(static_plan=static_plan)
+
+        ctx = {
+            "platform_id": "aerial.drone",
+            "platform_name": "Delivery Drone",
+            "platform_description": "A drone",
+            "context": {"typical_architecture": "ARM + NPU"},
+        }
+        state = create_initial_soc_state(goal="drone SoC", platform_context=ctx)
+
+        # Call the planner — with static plan it won't call LLM but should
+        # still process the state (the context enrichment only happens for
+        # non-static plans, which is correct)
+        result = planner(state)
+        assert "task_graph" in result


### PR DESCRIPTION
## Summary
- Wire platform context from registry into LLM prompts at 3 levels: state, planner, chat agent
- Platform context (architecture, pitfalls, regulatory) now reaches the LLM during design plan and chat
- Context persists in session state via new `platform_context` field on SoCDesignState

## How it works
```
User: "Design a drone perception SoC"
  → PlatformRegistry matches "aerial.multirotor_delivery" (score 0.95)
  → Platform context extracted: typical_architecture, common_pitfalls, regulatory
  → Injected into LLM system prompt before planning
  → Planner output references drone-specific constraints
```

## Changes
- `src/embodied_ai_architect/graphs/soc_state.py` — new `platform_context` field + parameter
- `src/embodied_ai_architect/graphs/planner.py` — auto-enrich system prompt from state
- `src/embodied_ai_architect/llm/agent.py` — `set_platform_context()` method for chat
- `src/embodied_ai_architect/cli/commands/design.py` — pass context into initial state
- `src/embodied_ai_architect/cli/commands/chat.py` — inject on first message
- `tests/test_platform_context_injection.py` — 9 tests

## Test plan
- [x] Fast CI passes
- [x] CodeRabbit review addressed

Resolves #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat now injects platform-specific context into the system prompt on the first user message (with optional verbose confirmation).
  * Design planner and state now carry platform-context metadata to produce more platform-aware recommendations and guidance.
* **Tests**
  * Added tests verifying platform-context propagation, prompt construction, and planner behavior when platform context is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->