### PR TITLE
docs: update landing page and introduction with mission workflow

### DIFF
--- a/docs-site/src/content/docs/getting-started/introduction.md
+++ b/docs-site/src/content/docs/getting-started/introduction.md
@@ -31,7 +31,8 @@ The Architect isn't just a tool—it's an AI that reasons about your requirement
 
 We analyze solutions across **commercial off-the-shelf** platforms (NVIDIA Jetson, Google Coral, Hailo, Intel) **and** custom AI accelerators:
 
-- **50+ COTS platforms** with calibrated performance data
+- **328 platform definitions** across 36 categories with 62 real-product configs
+- **80 sensors** and **80 actuators** searchable via TF-IDF keyword matching
 - **Pre-silicon modeling** for custom accelerators before tape-out
 - **Comparative analysis** across your options and competitor systems
 
@@ -43,17 +44,24 @@ Our characterization methodology lets you predict performance, cost, and energy 
 - Generate quantitative competitive analysis
 - Validate your differentiation before you build
 
-### 4. Full Lifecycle Support
+### 4. Mission-Driven Design Lifecycle
 
-From concept through production:
+The platform organizes all work around **missions** — persistent design entities
+that flow through 7 lifecycle phases:
 
-| Phase | What the Architect Does |
-|-------|------------------------|
-| **Design** | Explore hardware options, model architectures, quantization strategies |
-| **Analysis** | Roofline modeling, bottleneck identification, constraint checking |
-| **Optimization** | Recommend optimizations with predicted impact |
-| **Deployment** | Generate deployment configurations, quantization, runtime setup |
-| **Validation** | Verify deployed performance matches predictions |
+| Phase | Command | What happens |
+|-------|---------|-------------|
+| **Define** | `branes mission new` | Create a named mission with a goal |
+| **Qualify** | `branes design qualify --mission` | Derive constraints, match platforms |
+| **Select** | `branes sensor/actuator select` | Choose components from registries |
+| **Synthesize** | `branes synthesize system` | Compose architecture from selections |
+| **Analyze** | `branes analyze-system` | Power, latency, thermal, SWaP-C checks |
+| **Optimize** | `branes optimize explore --mission` | Multi-objective Pareto exploration |
+| **Validate** | `branes validate mission` | Verify all constraints pass |
+
+Every command reads from and writes to the same mission. State persists across
+sessions — you can close the terminal, come back tomorrow, and pick up where
+you left off.
 
 ## Why Custom Matters
 
@@ -97,5 +105,7 @@ The Embodied AI Architect is the design interface to the **Branes Embodied AI Pl
 ## Next Steps
 
 - [Install the platform](/getting-started/installation/)
-- [Run your first analysis](/getting-started/quickstart/)
+- [Run your first mission](/getting-started/quickstart/)
+- [Follow the mission workflow tutorial](/tutorials/mission-workflow/)
 - [Explore the hardware catalog](/catalog/hardware/)
+- [Browse the CLI reference](/reference/cli/)

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -43,6 +43,35 @@ As Product Architect, you need to identify performance and energy-efficiency req
 	</Card>
 </CardGrid>
 
+## Mission-Driven Design Lifecycle
+
+The Branes platform organizes design work around **missions** — persistent entities
+that capture your goal, constraints, and component selections across sessions.
+
+```bash
+# Define what to build
+branes mission new my-drone --goal "Drone perception SoC for YOLO at 30fps under 5W"
+
+# Derive constraints from the goal
+branes design qualify --mission my-drone --auto
+
+# Search and select sensors
+branes sensor search "stereo camera for VIO"
+branes sensor select my-drone visual.stereo_camera inertial.imu_6dof
+
+# Generate a design plan
+branes design plan --mission my-drone --static
+
+# Synthesize and validate
+branes synthesize system my-drone
+branes validate mission my-drone
+```
+
+Every command operates on the same mission entity. State flows forward through
+7 lifecycle phases: **Define → Qualify → Select → Synthesize → Analyze → Optimize → Validate**.
+
+[Follow the full tutorial →](./tutorials/mission-workflow/)
+
 ## Why Custom Matters
 
 Commodity AI hardware serves commodity use cases. But breakthrough products—autonomous vehicles, surgical robots, industrial drones—require **purpose-built solutions** that optimize the entire stack:
@@ -104,8 +133,8 @@ The Embodied AI Architect is the design interface to the **Branes Embodied AI Pl
 	<Card title="Design & Analysis" icon="pencil">
 		Roofline modeling, constraint checking, architecture exploration, competitive benchmarking
 	</Card>
-	<Card title="Hardware Catalog" icon="seti:folder">
-		50+ COTS platforms with calibrated performance data, plus custom accelerator modeling
+	<Card title="Hardware & Component Catalog" icon="seti:folder">
+		328 platforms, 80 sensors, 80 actuators, 62 product configs — all searchable with TF-IDF matching
 	</Card>
 	<Card title="Pre-Silicon Targets" icon="seti:config">
 		Model custom accelerators before tape-out. Validate architectures against requirements early.
@@ -125,6 +154,7 @@ The Embodied AI Architect is the design interface to the **Branes Embodied AI Pl
 ## Get Started
 
 1. [Understand the platform](./getting-started/introduction/)
-2. [Install and run your first analysis](./getting-started/installation/)
-3. [Explore the hardware catalog](./catalog/hardware/)
-4. [See what custom silicon enables](./tutorials/)
+2. [Install and run your first mission](./getting-started/quickstart/)
+3. [Follow the mission workflow tutorial](./tutorials/mission-workflow/)
+4. [Explore the hardware catalog](./catalog/hardware/)
+5. [Browse the CLI reference](./reference/cli/)


### PR DESCRIPTION
## Summary
- Landing page: added "Mission-Driven Design Lifecycle" section with CLI example, updated catalog counts
- Introduction: replaced lifecycle table with 7-phase mission workflow, updated platform/sensor counts
- Both pages link to quickstart, tutorial, and CLI reference

## Test plan
- [x] Fast CI passes (docs-only)

Resolves #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)