### PR TITLE
fix(mission): resolve missions by name when ID lookup fails

### DIFF
--- a/src/embodied_ai_architect/mission/store.py
+++ b/src/embodied_ai_architect/mission/store.py
@@ -67,16 +67,33 @@ class MissionStore:
         logger.debug("Saved mission %s to %s", mission.id, manifest)
         return mission.id
 
-    def load(self, mission_id: str) -> Optional[Mission]:
-        """Load a mission by ID. Returns None if not found."""
-        manifest = self._root / mission_id / "manifest.json"
-        if not manifest.exists():
-            return None
+    def load(self, identifier: str) -> Optional[Mission]:
+        """Load a mission by ID or name. Returns None if not found.
 
-        with open(manifest, encoding="utf-8") as f:
-            data = json.load(f)
+        Tries exact ID match first (directory lookup). If that fails,
+        scans all missions for a matching name field.
+        """
+        # Try exact ID match
+        manifest = self._root / identifier / "manifest.json"
+        if manifest.exists():
+            with open(manifest, encoding="utf-8") as f:
+                data = json.load(f)
+            return Mission(**data)
 
-        return Mission(**data)
+        # Fall back to name search
+        return self._find_by_name(identifier)
+
+    def _find_by_name(self, name: str) -> Optional[Mission]:
+        """Scan missions for one matching the given name."""
+        for manifest in self._list_manifests():
+            try:
+                with open(manifest, encoding="utf-8") as f:
+                    data = json.load(f)
+                if data.get("name") == name:
+                    return Mission(**data)
+            except (json.JSONDecodeError, OSError):
+                continue
+        return None
 
     def load_latest(self) -> Optional[Mission]:
         """Load the most recently updated mission."""
@@ -119,23 +136,35 @@ class MissionStore:
         summaries.sort(key=lambda s: s.get("updated_at", ""), reverse=True)
         return summaries
 
-    def delete(self, mission_id: str) -> bool:
-        """Delete a mission and its directory. Returns True if deleted."""
-        mission_dir = self._root / mission_id
+    def delete(self, identifier: str) -> bool:
+        """Delete a mission by ID or name. Returns True if deleted."""
+        resolved_id = self._resolve_id(identifier)
+        if not resolved_id:
+            return False
+
+        mission_dir = self._root / resolved_id
         if not mission_dir.is_dir():
             return False
 
-        # Remove all files in the mission directory, then the directory
         for f in mission_dir.iterdir():
             f.unlink()
         mission_dir.rmdir()
 
-        logger.debug("Deleted mission %s", mission_id)
+        logger.debug("Deleted mission %s", resolved_id)
         return True
 
-    def exists(self, mission_id: str) -> bool:
-        """Check if a mission exists on disk."""
-        return (self._root / mission_id / "manifest.json").exists()
+    def exists(self, identifier: str) -> bool:
+        """Check if a mission exists by ID or name."""
+        if (self._root / identifier / "manifest.json").exists():
+            return True
+        return self._find_by_name(identifier) is not None
+
+    def _resolve_id(self, identifier: str) -> Optional[str]:
+        """Resolve an identifier (ID or name) to a mission ID."""
+        if (self._root / identifier / "manifest.json").exists():
+            return identifier
+        mission = self._find_by_name(identifier)
+        return mission.id if mission else None
 
     def _list_manifests(self) -> list[Path]:
         """Find all manifest.json files under the root."""

--- a/tests/test_mission_name_lookup.py
+++ b/tests/test_mission_name_lookup.py
@@ -1,0 +1,67 @@
+"""Tests for mission name-based lookup (issue #140)."""
+
+import pytest
+
+from embodied_ai_architect.mission.models import Mission
+from embodied_ai_architect.mission.store import MissionStore
+
+
+@pytest.fixture()
+def store(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    return MissionStore()
+
+
+@pytest.fixture()
+def saved_mission(store):
+    m = Mission(name="vineyard-sprayer", goal="autonomous vineyard sprayer")
+    store.save(m)
+    return m
+
+
+class TestLoadByName:
+    def test_load_by_id(self, store, saved_mission):
+        loaded = store.load(saved_mission.id)
+        assert loaded is not None
+        assert loaded.name == "vineyard-sprayer"
+
+    def test_load_by_name(self, store, saved_mission):
+        loaded = store.load("vineyard-sprayer")
+        assert loaded is not None
+        assert loaded.id == saved_mission.id
+        assert loaded.goal == "autonomous vineyard sprayer"
+
+    def test_load_nonexistent_returns_none(self, store):
+        assert store.load("nonexistent") is None
+
+    def test_id_takes_precedence_over_name(self, store):
+        """If a mission's ID matches, return it even if name differs."""
+        m = Mission(id="my-id", name="my-name", goal="test")
+        store.save(m)
+        loaded = store.load("my-id")
+        assert loaded is not None
+        assert loaded.name == "my-name"
+
+
+class TestExistsByName:
+    def test_exists_by_id(self, store, saved_mission):
+        assert store.exists(saved_mission.id)
+
+    def test_exists_by_name(self, store, saved_mission):
+        assert store.exists("vineyard-sprayer")
+
+    def test_not_exists(self, store):
+        assert not store.exists("nonexistent")
+
+
+class TestDeleteByName:
+    def test_delete_by_name(self, store, saved_mission):
+        assert store.delete("vineyard-sprayer")
+        assert store.load(saved_mission.id) is None
+
+    def test_delete_by_id(self, store, saved_mission):
+        assert store.delete(saved_mission.id)
+        assert store.load("vineyard-sprayer") is None
+
+    def test_delete_nonexistent(self, store):
+        assert not store.delete("nonexistent")

--- a/tests/test_mission_name_lookup.py
+++ b/tests/test_mission_name_lookup.py
@@ -56,12 +56,15 @@ class TestExistsByName:
 
 class TestDeleteByName:
     def test_delete_by_name(self, store, saved_mission):
-        assert store.delete("vineyard-sprayer")
+        result = store.delete("vineyard-sprayer")
+        assert result
         assert store.load(saved_mission.id) is None
 
     def test_delete_by_id(self, store, saved_mission):
-        assert store.delete(saved_mission.id)
+        result = store.delete(saved_mission.id)
+        assert result
         assert store.load("vineyard-sprayer") is None
 
     def test_delete_nonexistent(self, store):
-        assert not store.delete("nonexistent")
+        result = store.delete("nonexistent")
+        assert not result

--- a/tests/test_mission_name_lookup.py
+++ b/tests/test_mission_name_lookup.py
@@ -64,7 +64,8 @@ class TestDeleteByName:
         result = store.delete(saved_mission.id)
         assert result
         assert store.load("vineyard-sprayer") is None
-
+        deleted = store.delete("nonexistent")
+        assert not deleted
     def test_delete_nonexistent(self, store):
         result = store.delete("nonexistent")
         assert not result

--- a/tests/test_mission_name_lookup.py
+++ b/tests/test_mission_name_lookup.py
@@ -64,8 +64,7 @@ class TestDeleteByName:
         result = store.delete(saved_mission.id)
         assert result
         assert store.load("vineyard-sprayer") is None
-        deleted = store.delete("nonexistent")
-        assert not deleted
+
     def test_delete_nonexistent(self, store):
         result = store.delete("nonexistent")
         assert not result


### PR DESCRIPTION
## Summary
- `MissionStore.load()`, `delete()`, `exists()` now accept ID or name
- Exact ID tried first; falls back to name scan
- Enables `branes mission show vineyard-sprayer` instead of `mission_bda1b5ca5f50`

## Changes
- `src/embodied_ai_architect/mission/store.py` — `_find_by_name()`, `_resolve_id()`, updated load/delete/exists
- `tests/test_mission_name_lookup.py` — 10 tests

## Test plan
- [x] Fast CI passes

Resolves #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mission store operations (load, delete, exists) now accept either a mission ID or mission name and resolve identifiers accordingly; exact ID matches take precedence.

* **Bug Fixes**
  * Name-based lookup now skips unreadable or invalid manifest entries instead of failing.

* **Tests**
  * Added tests covering name-based lookup, existence checks, precedence rules, and deletion by name or ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->