### PR TITLE
test: CLI coverage for design, select, synthesize, analyze-system, platform, spec

### DIFF
--- a/tests/test_analyze_system_cli.py
+++ b/tests/test_analyze_system_cli.py
@@ -1,0 +1,43 @@
+"""Tests for the branes analyze-system CLI command group."""
+
+import pytest
+from click.testing import CliRunner
+
+from embodied_ai_architect.cli.commands.analyze_group import analyze_lifecycle
+
+pytestmark = pytest.mark.cli
+
+
+def _make_runner():
+    return CliRunner()
+
+
+_STUB_SUBCOMMANDS = [
+    "power",
+    "latency",
+    "thermal",
+    "swap",
+    "safety",
+    "cost",
+    "bandwidth",
+    "scheduling",
+]
+
+
+class TestAnalyzeLifecycleStubs:
+    @pytest.mark.parametrize("subcmd", _STUB_SUBCOMMANDS)
+    def test_stub_exits_zero(self, subcmd):
+        runner = _make_runner()
+        result = runner.invoke(analyze_lifecycle, [subcmd, "dummy_mission"], obj={})
+        assert result.exit_code == 0, result.output
+        assert "Coming in a future release" in result.output
+
+
+class TestAnalyzeLifecycleHelp:
+    def test_no_subcommand_shows_help(self):
+        runner = _make_runner()
+        result = runner.invoke(analyze_lifecycle, [], obj={})
+        assert result.exit_code == 0
+        # Help should list subcommands
+        for subcmd in _STUB_SUBCOMMANDS:
+            assert subcmd in result.output

--- a/tests/test_design_cli.py
+++ b/tests/test_design_cli.py
@@ -1,0 +1,92 @@
+"""Tests for the branes design CLI command group."""
+
+import pytest
+from click.testing import CliRunner
+
+from embodied_ai_architect.cli.commands.design import design
+from embodied_ai_architect.mission import Mission, MissionStore
+import embodied_ai_architect.mission.store as store_mod
+
+pytestmark = pytest.mark.cli
+
+
+@pytest.fixture(autouse=True)
+def _use_tmp_store(tmp_path, monkeypatch):
+    """Isolate MissionStore to a temp directory."""
+    monkeypatch.setattr(store_mod, "DEFAULT_MISSIONS_DIR", tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+
+def _make_runner():
+    return CliRunner()
+
+
+class TestDesignQualify:
+    def test_qualify_with_goal_auto(self):
+        runner = _make_runner()
+        result = runner.invoke(
+            design,
+            ["qualify", "drone SoC", "--auto"],
+            obj={},
+            input="\n" * 50,
+        )
+        assert result.exit_code == 0, result.output
+
+    def test_qualify_with_mission_auto(self):
+        store = MissionStore()
+        m = Mission(name="Test Drone", goal="30fps at <5W")
+        store.save(m)
+
+        runner = _make_runner()
+        result = runner.invoke(
+            design,
+            ["qualify", "--mission", m.id, "--auto"],
+            obj={},
+            input="\n" * 50,
+        )
+        assert result.exit_code == 0, result.output
+
+
+class TestDesignPlan:
+    def test_plan_with_goal_static(self):
+        runner = _make_runner()
+        result = runner.invoke(
+            design,
+            ["plan", "drone SoC", "--static"],
+            obj={},
+        )
+        assert result.exit_code == 0, result.output
+
+    def test_plan_with_mission_static(self):
+        store = MissionStore()
+        m = Mission(name="Test Drone", goal="30fps at <5W")
+        store.save(m)
+
+        runner = _make_runner()
+        result = runner.invoke(
+            design,
+            ["plan", "--mission", m.id, "--static"],
+            obj={},
+        )
+        assert result.exit_code == 0, result.output
+        assert "Loaded mission" in result.output
+
+    def test_plan_no_goal_no_mission(self):
+        runner = _make_runner()
+        result = runner.invoke(
+            design,
+            ["plan"],
+            obj={},
+        )
+        assert result.exit_code != 0
+
+    def test_plan_static_shows_task_graph(self):
+        runner = _make_runner()
+        result = runner.invoke(
+            design,
+            ["plan", "drone SoC", "--static"],
+            obj={},
+        )
+        assert result.exit_code == 0
+        # Static plan includes known agent names
+        assert "workload" in result.output.lower() or "plan" in result.output.lower()

--- a/tests/test_platform_cli.py
+++ b/tests/test_platform_cli.py
@@ -1,0 +1,71 @@
+"""Tests for the branes platform CLI command group."""
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from embodied_ai_architect.cli.commands.platform import platform
+
+pytestmark = pytest.mark.cli
+
+
+def _make_runner():
+    return CliRunner()
+
+
+class TestPlatformList:
+    def test_lists_platforms(self):
+        runner = _make_runner()
+        result = runner.invoke(platform, ["list"], obj={})
+        assert result.exit_code == 0, result.output
+        assert "Platform Registry" in result.output
+
+    def test_with_category_filter(self):
+        runner = _make_runner()
+        result = runner.invoke(platform, ["list", "--category", "aerial"], obj={})
+        assert result.exit_code == 0, result.output
+
+    def test_json_output(self):
+        runner = _make_runner()
+        result = runner.invoke(platform, ["list", "--json"], obj={})
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        if data:
+            assert "id" in data[0]
+            assert "name" in data[0]
+
+
+class TestPlatformSearch:
+    def test_search_delivery_drone(self):
+        runner = _make_runner()
+        result = runner.invoke(platform, ["search", "delivery drone"], obj={})
+        assert result.exit_code == 0, result.output
+
+    def test_search_json(self):
+        runner = _make_runner()
+        result = runner.invoke(platform, ["search", "drone", "--json"], obj={})
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+
+
+class TestPlatformShow:
+    def test_show_known_platform(self):
+        runner = _make_runner()
+        result = runner.invoke(platform, ["show", "aerial.agricultural_sprayer"], obj={})
+        assert result.exit_code == 0, result.output
+
+    def test_show_nonexistent(self):
+        runner = _make_runner()
+        result = runner.invoke(platform, ["show", "nonexistent_xyz_123"], obj={})
+        assert result.exit_code != 0
+
+
+class TestPlatformCategories:
+    def test_lists_categories(self):
+        runner = _make_runner()
+        result = runner.invoke(platform, ["categories"], obj={})
+        assert result.exit_code == 0
+        assert "Categories" in result.output

--- a/tests/test_select_cli.py
+++ b/tests/test_select_cli.py
@@ -1,0 +1,84 @@
+"""Tests for the branes select CLI command group."""
+
+import pytest
+from click.testing import CliRunner
+
+from embodied_ai_architect.cli.commands.select import select
+from embodied_ai_architect.mission import Mission, MissionStore
+import embodied_ai_architect.mission.store as store_mod
+
+pytestmark = pytest.mark.cli
+
+
+@pytest.fixture(autouse=True)
+def _use_tmp_store(tmp_path, monkeypatch):
+    """Isolate MissionStore to a temp directory."""
+    monkeypatch.setattr(store_mod, "DEFAULT_MISSIONS_DIR", tmp_path)
+
+
+@pytest.fixture()
+def mission_id():
+    """Create a mission and return its ID."""
+    store = MissionStore()
+    m = Mission(name="Test Mission", goal="Test goal")
+    store.save(m)
+    return m.id
+
+
+def _make_runner():
+    return CliRunner()
+
+
+class TestSelectSensor:
+    def test_adds_sensor(self, mission_id):
+        runner = _make_runner()
+        result = runner.invoke(
+            select,
+            ["sensor", mission_id, "visual.rgb_camera"],
+            obj={},
+        )
+        assert result.exit_code == 0, result.output
+
+        # Verify sensor was added to mission
+        store = MissionStore()
+        m = store.load(mission_id)
+        assert "visual.rgb_camera" in m.selected_sensors
+
+
+class TestSelectActuator:
+    def test_adds_actuator(self, mission_id):
+        runner = _make_runner()
+        result = runner.invoke(
+            select,
+            ["actuator", mission_id, "motor.servo"],
+            obj={},
+        )
+        assert result.exit_code == 0, result.output
+
+        store = MissionStore()
+        m = store.load(mission_id)
+        assert "motor.servo" in m.selected_actuators
+
+
+class TestSelectCompute:
+    def test_shows_coming_soon(self, mission_id):
+        runner = _make_runner()
+        result = runner.invoke(
+            select,
+            ["compute", mission_id],
+            obj={},
+        )
+        assert result.exit_code == 0
+        assert "Coming in a future release" in result.output
+
+
+class TestSelectModel:
+    def test_shows_coming_soon(self, mission_id):
+        runner = _make_runner()
+        result = runner.invoke(
+            select,
+            ["model", mission_id],
+            obj={},
+        )
+        assert result.exit_code == 0
+        assert "Coming in a future release" in result.output

--- a/tests/test_spec_cli.py
+++ b/tests/test_spec_cli.py
@@ -1,0 +1,110 @@
+"""Tests for the branes spec CLI command group."""
+
+import pytest
+from click.testing import CliRunner
+
+from embodied_ai_architect.cli.commands.spec import spec
+import embodied_ai_architect.mission.store as store_mod
+
+pytestmark = pytest.mark.cli
+
+
+@pytest.fixture(autouse=True)
+def _use_tmp_dirs(tmp_path, monkeypatch):
+    """Isolate both SpecStore (cwd-based) and MissionStore to tmp."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(store_mod, "DEFAULT_MISSIONS_DIR", tmp_path / "missions")
+
+
+def _make_runner():
+    return CliRunner()
+
+
+class TestSpecNew:
+    def test_creates_spec(self):
+        runner = _make_runner()
+        result = runner.invoke(spec, ["new", "test-spec"], obj={})
+        assert result.exit_code == 0, result.output
+        assert "Created spec" in result.output
+        assert "test-spec" in result.output
+
+    def test_creates_spec_with_description(self):
+        runner = _make_runner()
+        result = runner.invoke(spec, ["new", "my-drone", "-d", "A test drone spec"], obj={})
+        assert result.exit_code == 0
+        assert "my-drone" in result.output
+
+
+class TestSpecList:
+    def test_empty_list(self):
+        runner = _make_runner()
+        result = runner.invoke(spec, ["list"], obj={})
+        assert result.exit_code == 0
+        assert "No specs found" in result.output
+
+    def test_list_after_create(self):
+        runner = _make_runner()
+        runner.invoke(spec, ["new", "alpha"], obj={})
+        result = runner.invoke(spec, ["list"], obj={})
+        assert result.exit_code == 0
+        assert "alpha" in result.output
+
+
+class TestSpecShow:
+    def test_show_existing(self):
+        runner = _make_runner()
+        runner.invoke(spec, ["new", "test-spec"], obj={})
+        result = runner.invoke(spec, ["show", "test-spec"], obj={})
+        assert result.exit_code == 0
+        assert "test-spec" in result.output
+
+    def test_show_nonexistent(self):
+        runner = _make_runner()
+        result = runner.invoke(spec, ["show", "nonexistent"], obj={})
+        assert result.exit_code != 0
+
+
+class TestSpecSet:
+    def test_set_field(self):
+        runner = _make_runner()
+        runner.invoke(spec, ["new", "test-spec"], obj={})
+        result = runner.invoke(spec, ["set", "test-spec", "/perception/min_fps", "60"], obj={})
+        assert result.exit_code == 0, result.output
+        assert "Set" in result.output
+        assert "60" in result.output
+
+
+class TestSpecCommit:
+    def test_commit(self):
+        runner = _make_runner()
+        runner.invoke(spec, ["new", "test-spec"], obj={})
+        result = runner.invoke(spec, ["commit", "test-spec", "-m", "initial"], obj={})
+        assert result.exit_code == 0, result.output
+        assert "Committed" in result.output
+
+
+class TestSpecHistory:
+    def test_no_versions(self):
+        runner = _make_runner()
+        runner.invoke(spec, ["new", "test-spec"], obj={})
+        result = runner.invoke(spec, ["history", "test-spec"], obj={})
+        assert result.exit_code == 0
+        assert "No committed versions" in result.output
+
+    def test_with_versions(self):
+        runner = _make_runner()
+        runner.invoke(spec, ["new", "test-spec"], obj={})
+        runner.invoke(spec, ["commit", "test-spec", "-m", "v1"], obj={})
+        result = runner.invoke(spec, ["history", "test-spec"], obj={})
+        assert result.exit_code == 0
+        assert "v1" in result.output
+
+
+class TestSpecDelete:
+    def test_delete_field(self):
+        runner = _make_runner()
+        runner.invoke(spec, ["new", "test-spec"], obj={})
+        runner.invoke(spec, ["set", "test-spec", "/perception/min_fps", "60"], obj={})
+        result = runner.invoke(spec, ["delete", "test-spec", "/perception/min_fps"], obj={})
+        assert result.exit_code == 0, result.output
+        assert "Deleted" in result.output

--- a/tests/test_synthesize_cli.py
+++ b/tests/test_synthesize_cli.py
@@ -1,0 +1,94 @@
+"""Tests for the branes synthesize CLI command group."""
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from embodied_ai_architect.cli.commands.synthesize import synthesize
+from embodied_ai_architect.mission import Mission, MissionStore
+import embodied_ai_architect.mission.store as store_mod
+
+pytestmark = pytest.mark.cli
+
+
+@pytest.fixture(autouse=True)
+def _use_tmp_store(tmp_path, monkeypatch):
+    """Isolate MissionStore to a temp directory."""
+    monkeypatch.setattr(store_mod, "DEFAULT_MISSIONS_DIR", tmp_path)
+
+
+@pytest.fixture()
+def mission_id():
+    """Create a mission with sensors and return its ID."""
+    store = MissionStore()
+    m = Mission(
+        name="Test Drone",
+        goal="30fps at <5W",
+        selected_sensors=["visual.rgb_camera"],
+        selected_actuators=["motor.servo"],
+    )
+    store.save(m)
+    return m.id
+
+
+@pytest.fixture()
+def bare_mission_id():
+    """Create a mission with no selections."""
+    store = MissionStore()
+    m = Mission(name="Bare Mission", goal="Test")
+    store.save(m)
+    return m.id
+
+
+def _make_runner():
+    return CliRunner()
+
+
+class TestSynthesizeSystem:
+    def test_shows_summary(self, mission_id):
+        runner = _make_runner()
+        result = runner.invoke(synthesize, ["system", mission_id], obj={})
+        assert result.exit_code == 0, result.output
+        assert "Test Drone" in result.output
+        assert "visual.rgb_camera" in result.output
+
+    def test_json_output(self, mission_id):
+        runner = _make_runner()
+        result = runner.invoke(synthesize, ["system", mission_id], obj={"json": True})
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["mission"] == "Test Drone"
+        assert "visual.rgb_camera" in data["sensors"]
+
+    def test_not_found(self):
+        runner = _make_runner()
+        result = runner.invoke(synthesize, ["system", "nonexistent"], obj={})
+        assert result.exit_code != 0
+
+    def test_missing_selections_warning(self, bare_mission_id):
+        runner = _make_runner()
+        result = runner.invoke(synthesize, ["system", bare_mission_id], obj={})
+        assert result.exit_code == 0
+        assert "Missing selections" in result.output
+
+
+class TestSynthesizeArchitecture:
+    def test_shows_mermaid(self, mission_id):
+        runner = _make_runner()
+        result = runner.invoke(synthesize, ["architecture", mission_id], obj={})
+        assert result.exit_code == 0
+        assert "graph TD" in result.output or "mermaid" in result.output
+
+    def test_not_found(self):
+        runner = _make_runner()
+        result = runner.invoke(synthesize, ["architecture", "nonexistent"], obj={})
+        assert result.exit_code != 0
+
+
+class TestSynthesizeBom:
+    def test_shows_coming_soon(self, mission_id):
+        runner = _make_runner()
+        result = runner.invoke(synthesize, ["bom", mission_id], obj={})
+        assert result.exit_code == 0
+        assert "Coming in a future release" in result.output


### PR DESCRIPTION
## Summary
6 new CLI test files with 45 tests covering previously untested command groups:
- design (6), select (4), synthesize (7), analyze-system (9), platform (8), spec (11)
- CLI test count: 204 → 249 across 21 files

## Test plan
- [x] Fast CI passes

Resolves #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded comprehensive CLI test coverage across all major command groups: analyze-system, design, platform, select, spec, and synthesize.
  * Added integration tests validating command execution, output formatting, JSON response parsing, and error conditions.
  * Implemented isolated test environments for reliable mission storage and persistence testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->