### PR TITLE
ci: make optional dependency tests strict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     name: Test (optional deps)
     needs: lint
     runs-on: ubuntu-latest
-    continue-on-error: true
+    # No continue-on-error — failures are real failures
 
     steps:
       - uses: actions/checkout@v5
@@ -79,9 +79,12 @@ jobs:
         run: pip install -e ".[dev,optimization,api]"
 
       - name: Run MOO tests
-        run: |
-          pytest tests/test_moo_*.py tests/test_bayesian_*.py -v --tb=short \
-            --ignore=tests/agents/ || true
+        run: pytest tests/test_moo_*.py tests/test_bayesian_*.py -v --tb=short
 
       - name: Run API server tests
         run: pytest tests/test_api_server.py -v --tb=short
+
+      - name: Run agent tests (requires onnx)
+        run: |
+          pip install onnx onnxscript onnxruntime
+          pytest tests/agents/ -v --tb=short


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` — optional dep test failures now fail the build
- Remove `|| true` on MOO test step — must pass
- Add agent tests step with `onnx onnxscript onnxruntime` deps installed
- Agents were excluded from main CI because they need onnxscript; now run in optional deps job

## Changes
- `.github/workflows/ci.yml` — 3 fixes

## Investigation: why tests/agents/ was excluded
Agent tests (`test_deployment.py`) require `onnxscript` which is not in the base `[dev]` extras. Now they run in the optional deps job which installs the required packages.

## Test plan
- [x] All 3 CI jobs pass (lint, test, test-optional-deps)
- [ ] MOO tests pass without || true
- [ ] Agent tests pass with onnx deps

Resolves #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened test reliability by enforcing stricter failure detection in the testing pipeline.
  * Enhanced testing coverage for optional dependencies to improve overall code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->