### PR TITLE
fix(cli): batch fix for issues #167-#175

### DIFF
--- a/docs-site/src/content/docs/getting-started/installation.md
+++ b/docs-site/src/content/docs/getting-started/installation.md
@@ -5,7 +5,7 @@ description: How to install Embodied AI Architect and its dependencies.
 
 ## Requirements
 
-- Python 3.9 or higher
+- Python 3.11 or higher
 - pip or uv package manager
 
 ## Basic Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ authors = [
     {name = "Branes-ai Team"}
 ]
 dependencies = [
-    "torch>=2.0.0",
     "numpy>=1.24.0",
     "pydantic>=2.0.0",
     "matplotlib>=3.7.0",
@@ -25,6 +24,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+models = [
+    "torch>=2.0.0",
+]
+zoo = [
+    "ultralytics>=8.0.0",
+]
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",

--- a/src/embodied_ai_architect/cli/commands/api.py
+++ b/src/embodied_ai_architect/cli/commands/api.py
@@ -6,8 +6,9 @@ from rich.console import Console
 console = Console()
 
 
-@click.group()
-def api() -> None:
+@click.group(invoke_without_command=True)
+@click.pass_context
+def api(ctx) -> None:
     """Manage the REST API server.
 
     \\b
@@ -16,7 +17,8 @@ def api() -> None:
       branes api serve --port 9000        # Custom port
       branes api serve --host 0.0.0.0     # Listen on all interfaces
     """
-    pass
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
 
 
 @api.command()

--- a/src/embodied_ai_architect/cli/commands/backends.py
+++ b/src/embodied_ai_architect/cli/commands/backends.py
@@ -9,8 +9,9 @@ from rich.table import Table
 console = Console()
 
 
-@click.group()
-def backends():
+@click.group(invoke_without_command=True)
+@click.pass_context
+def backends(ctx):
     """Manage benchmark backends.
 
     \b
@@ -21,7 +22,8 @@ def backends():
       # Test backend connection
       branes backends test kubernetes
     """
-    pass
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
 
 
 @backends.command()

--- a/src/embodied_ai_architect/cli/commands/chat.py
+++ b/src/embodied_ai_architect/cli/commands/chat.py
@@ -17,7 +17,7 @@ console = Console()
 @click.command()
 @click.option(
     "--model",
-    default="claude-sonnet-4-20250514",
+    default="claude-sonnet-4-6",
     help="Claude model to use",
 )
 @click.option(
@@ -33,7 +33,7 @@ def chat(ctx, model: str, verbose: bool):
     \b
     Examples:
       branes chat
-      branes chat --model claude-sonnet-4-20250514
+      branes chat --model claude-sonnet-4-6
       branes chat -v
 
     \b

--- a/src/embodied_ai_architect/cli/commands/config.py
+++ b/src/embodied_ai_architect/cli/commands/config.py
@@ -10,8 +10,9 @@ from rich.syntax import Syntax
 console = Console()
 
 
-@click.group()
-def config():
+@click.group(invoke_without_command=True)
+@click.pass_context
+def config(ctx):
     """Manage configuration settings.
 
     \b
@@ -22,7 +23,8 @@ def config():
       # Initialize configuration
       branes config init
     """
-    pass
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
 
 
 @config.command()

--- a/src/embodied_ai_architect/cli/commands/mission.py
+++ b/src/embodied_ai_architect/cli/commands/mission.py
@@ -23,8 +23,9 @@ from rich.table import Table
 console = Console()
 
 
-@click.group()
-def mission():
+@click.group(invoke_without_command=True)
+@click.pass_context
+def mission(ctx):
     """Manage design missions.
 
     \\b
@@ -37,7 +38,8 @@ def mission():
       branes mission refine <mission_id>
       branes mission fork <source_id> "What-If Variant"
     """
-    pass
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
 
 
 @mission.command("new")
@@ -99,7 +101,7 @@ def mission_list(ctx):
         return
 
     table = Table(title="Design Missions", show_header=True)
-    table.add_column("ID", style="cyan", max_width=20)
+    table.add_column("ID", style="cyan", no_wrap=True)
     table.add_column("Name")
     table.add_column("Status")
     table.add_column("Goal", max_width=40)
@@ -124,6 +126,7 @@ def mission_list(ctx):
         )
 
     console.print(table)
+    console.print("[dim]Tip: use mission name instead of ID for all commands[/dim]")
 
 
 @mission.command("show")

--- a/src/embodied_ai_architect/cli/commands/secrets.py
+++ b/src/embodied_ai_architect/cli/commands/secrets.py
@@ -11,8 +11,9 @@ from rich.table import Table
 console = Console()
 
 
-@click.group()
-def secrets():
+@click.group(invoke_without_command=True)
+@click.pass_context
+def secrets(ctx):
     """Manage secrets and credentials.
 
     \b
@@ -26,7 +27,8 @@ def secrets():
       # Validate secrets setup
       branes secrets validate
     """
-    pass
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
 
 
 @secrets.command()

--- a/src/embodied_ai_architect/cli/commands/session.py
+++ b/src/embodied_ai_architect/cli/commands/session.py
@@ -14,8 +14,9 @@ from rich.table import Table
 console = Console()
 
 
-@click.group()
-def session():
+@click.group(invoke_without_command=True)
+@click.pass_context
+def session(ctx):
     """Manage saved design sessions.
 
     \\b
@@ -25,7 +26,8 @@ def session():
       branes session show --latest           # Inspect most recent
       branes session delete soc_abc123       # Delete a session
     """
-    pass
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
 
 
 @session.command("list")

--- a/src/embodied_ai_architect/cli/commands/spec.py
+++ b/src/embodied_ai_architect/cli/commands/spec.py
@@ -15,8 +15,9 @@ from rich.tree import Tree
 console = Console()
 
 
-@click.group()
-def spec():
+@click.group(invoke_without_command=True)
+@click.pass_context
+def spec(ctx):
     """Manage system specifications with versioning and provenance.
 
     \b
@@ -28,7 +29,8 @@ def spec():
       branes spec history my-drone
       branes spec why my-drone /perception/min_fps
     """
-    pass
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
 
 
 @spec.command("new")

--- a/src/embodied_ai_architect/cli/commands/swap.py
+++ b/src/embodied_ai_architect/cli/commands/swap.py
@@ -268,7 +268,7 @@ def estimate(
     content = (
         f"  Weight:    {weight:.1f} g\n"
         f"  Volume:    {volume:.1f} cm³\n"
-        f"  Cost:      ${cost:.2f}\n"
+        f"  Unit Cost (NRE-amortized):  ${cost:.2f}\n"
         f"  Dims:      {dims.length_mm:.0f}×{dims.width_mm:.0f}×{dims.height_mm:.0f} mm\n"
         f"  Thermal:   Tj={tj:.0f}°C (margin: {margin:.0f}°C) {thermal_icon}"
     )
@@ -279,6 +279,14 @@ def estimate(
             border_style="cyan",
         )
     )
+    if not feasible:
+        console.print()
+        console.print("[bold yellow]Thermal remediation suggestions:[/bold yellow]")
+        console.print("  1. Switch to active cooling (fan or heat-pipe)")
+        console.print("  2. Reduce power budget or clock frequency")
+        console.print("  3. Move to a smaller process node for lower power density")
+        console.print("  4. Increase die area to spread heat over a larger surface")
+        console.print("  5. Use a package with better thermal conductivity (e.g., flip-chip)")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **#167** (BUG-014): Seven CLI group commands (`config`, `secrets`, `session`, `api`, `backends`, `spec`, `mission`) hang when invoked without a subcommand. Added `invoke_without_command=True` and a help-printing fallback to each.
- **#168** (BUG-015): `pip install` downloads 4.5 GB PyTorch as a hard dependency. Moved `torch` to a new `[models]` optional-dependencies group.
- **#169** (BUG-009): `mission list` truncates the ID column. Changed to `no_wrap=True` and added a tip footer suggesting mission names over IDs.
- **#170** (BUG-010): `swap estimate` cost field had no descriptive label. Changed to "Unit Cost (NRE-amortized)".
- **#171** (BUG-011): `swap estimate` thermal FAIL provides no remediation guidance. Added five actionable suggestions when thermal check fails.
- **#172** (BUG-016): Docs claim Python 3.9+ but `pyproject.toml` requires 3.11+. Fixed docs to say 3.11.
- **#174** (BUG-018): `zoo download` fails due to undeclared `ultralytics` dependency. Added `[zoo]` optional-dependencies group.
- **#175** (BUG-012): `chat --help` references outdated model `claude-sonnet-4-20250514`. Updated to `claude-sonnet-4-6`.

Closes #167, #168, #169, #170, #171, #172, #174, #175

## Test plan

- [x] `black --check src/` passes
- [x] `ruff check src/` passes
- [x] `pytest tests/test_swap_cli.py tests/test_mission_cli.py -q` — 43 tests pass
- [ ] Manual: `branes config` / `branes secrets` / `branes session` / `branes api` / `branes backends` / `branes spec` / `branes mission` print help instead of hanging
- [ ] Manual: `pip install .` no longer pulls PyTorch; `pip install ".[models]"` does
- [ ] Manual: `branes chat --help` shows `claude-sonnet-4-6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Python version requirement to 3.11+.

* **New Features**
  * Improved CLI behavior: command groups now display help text when invoked without subcommands.
  * Added thermal remediation suggestions for unfeasible estimates.

* **Chores**
  * Restructured dependencies: PyTorch is now optional via `[models]` group; added `[zoo]` optional group for ultralytics support.
  * Updated cost reporting label in estimates for clarity.
  * Updated default model version in chat command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->