### PR TITLE
fix: parse goal constraints, populate mission, exit 1 on skip (#164, #165, #166)

### DIFF
--- a/src/embodied_ai_architect/cli/commands/actuator.py
+++ b/src/embodied_ai_architect/cli/commands/actuator.py
@@ -233,6 +233,19 @@ def actuator_select(ctx, mission_id, actuator_ids):
     if added:
         store.save(mission)
 
+    # BUG-008 / #166: exit 1 when all requested actuators were skipped
+    if not added and skipped:
+        if json_output:
+            click.echo(
+                json.dumps(
+                    {"added": added, "skipped": skipped, "total": mission.selected_actuators}
+                )
+            )
+        else:
+            console.print(f"[red]No actuators added — {len(skipped)} not found in registry.[/red]")
+        ctx.exit(1)
+        return
+
     if json_output:
         click.echo(
             json.dumps({"added": added, "skipped": skipped, "total": mission.selected_actuators})

--- a/src/embodied_ai_architect/cli/commands/mission.py
+++ b/src/embodied_ai_architect/cli/commands/mission.py
@@ -55,12 +55,30 @@ def mission_new(ctx, name, goal, platform_id, use_case):
       branes mission new "Warehouse AMR" --platform ground_wheeled.warehouse_amr
     """
     from embodied_ai_architect.mission import Mission, MissionStore
+    from embodied_ai_architect.mission.goal_parser import parse_goal_constraints
+
+    # Parse numeric constraints from the goal string so that
+    # ``mission show`` and ``design validate`` see them immediately
+    # (BUG-007 / #165).
+    parsed = parse_goal_constraints(goal)
+    constraints: dict = {}
+    if "power_watts" in parsed:
+        constraints["max_power_watts"] = parsed["power_watts"]
+    if "latency_ms" in parsed:
+        constraints["max_latency_ms"] = parsed["latency_ms"]
+    if "cost_usd" in parsed:
+        constraints["max_cost_usd"] = parsed["cost_usd"]
+
+    # Infer platform from goal text when not explicitly provided
+    if platform_id is None and "platform" in parsed:
+        platform_id = parsed["platform"]
 
     m = Mission(
         name=name,
         goal=goal,
         platform_id=platform_id,
         use_case=use_case,
+        constraints=constraints,
     )
 
     store = MissionStore()

--- a/src/embodied_ai_architect/cli/commands/sensor.py
+++ b/src/embodied_ai_architect/cli/commands/sensor.py
@@ -232,6 +232,17 @@ def sensor_select(ctx, mission_id, sensor_ids):
     if added:
         store.save(mission)
 
+    # BUG-008 / #166: exit 1 when all requested sensors were skipped
+    if not added and skipped:
+        if json_output:
+            click.echo(
+                json.dumps({"added": added, "skipped": skipped, "total": mission.selected_sensors})
+            )
+        else:
+            console.print(f"[red]No sensors added — {len(skipped)} not found in registry.[/red]")
+        ctx.exit(1)
+        return
+
     if json_output:
         click.echo(
             json.dumps({"added": added, "skipped": skipped, "total": mission.selected_sensors})

--- a/src/embodied_ai_architect/mission/goal_parser.py
+++ b/src/embodied_ai_architect/mission/goal_parser.py
@@ -1,0 +1,109 @@
+"""Goal string parser — extracts numeric constraints from natural language.
+
+Shared helper used by both the GoalQualifier (BUG-006 / #164) and the
+``mission new`` CLI command (BUG-007 / #165) so that a goal such as
+"Drone perception SoC for YOLO at 30fps under 5W" automatically
+populates constraints and spec fields.
+
+Usage:
+    from embodied_ai_architect.mission.goal_parser import parse_goal_constraints
+
+    parsed = parse_goal_constraints("Drone perception SoC for YOLO at 30fps under 5W")
+    # parsed == {
+    #     "power_watts": 5.0,
+    #     "latency_ms": 33.333...,
+    #     "platform": "drone",
+    # }
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# ── Regex patterns ──────────────────────────────────────────────────────
+
+_POWER_PATTERNS = [
+    # "under 5W", "under 5 W", "under 5.0W"
+    re.compile(r"under\s+(\d+\.?\d*)\s*[Ww]", re.IGNORECASE),
+    # "<5W", "< 5W", "< 5.0 W"
+    re.compile(r"<\s*(\d+\.?\d*)\s*[Ww]", re.IGNORECASE),
+    # "5W budget", "5 W power", plain "5W" (must not be preceded by digit)
+    re.compile(r"(?<!\d)(\d+\.?\d*)\s*[Ww](?:att)?s?\b", re.IGNORECASE),
+]
+
+_FPS_PATTERN = re.compile(r"(\d+)\s*fps", re.IGNORECASE)
+
+_COST_PATTERNS = [
+    # "<$100", "< $100"
+    re.compile(r"<\s*\$\s*(\d+\.?\d*)", re.IGNORECASE),
+    # "under $100"
+    re.compile(r"under\s+\$\s*(\d+\.?\d*)", re.IGNORECASE),
+]
+
+_LATENCY_PATTERN = re.compile(r"(\d+\.?\d*)\s*ms", re.IGNORECASE)
+
+# Platform keyword → canonical platform name
+_PLATFORM_KEYWORDS: dict[str, str] = {
+    "drone": "drone",
+    "uav": "drone",
+    "quadrotor": "drone",
+    "multirotor": "drone",
+    "robot": "robot_arm",
+    "cobot": "robot_arm",
+    "robotic arm": "robot_arm",
+    "amr": "ugv",
+    "warehouse": "ugv",
+    "ugv": "ugv",
+    "ground vehicle": "ugv",
+}
+
+
+def parse_goal_constraints(goal: str) -> dict[str, Any]:
+    """Extract numeric constraints and platform from a goal string.
+
+    Returns a dict that may contain any subset of:
+        - ``power_watts`` (float)
+        - ``latency_ms`` (float)
+        - ``cost_usd`` (float)
+        - ``platform`` (str)
+    """
+    result: dict[str, Any] = {}
+    if not goal:
+        return result
+
+    # ── Power ───────────────────────────────────────────────────────
+    for pat in _POWER_PATTERNS:
+        m = pat.search(goal)
+        if m:
+            result["power_watts"] = float(m.group(1))
+            break
+
+    # ── FPS → latency ───────────────────────────────────────────────
+    m = _FPS_PATTERN.search(goal)
+    if m:
+        fps = int(m.group(1))
+        if fps > 0:
+            result["latency_ms"] = 1000.0 / fps
+
+    # ── Explicit latency in ms (only if no fps was found) ───────────
+    if "latency_ms" not in result:
+        m = _LATENCY_PATTERN.search(goal)
+        if m:
+            result["latency_ms"] = float(m.group(1))
+
+    # ── Cost ────────────────────────────────────────────────────────
+    for pat in _COST_PATTERNS:
+        m = pat.search(goal)
+        if m:
+            result["cost_usd"] = float(m.group(1))
+            break
+
+    # ── Platform ────────────────────────────────────────────────────
+    goal_lower = goal.lower()
+    for keyword, platform in _PLATFORM_KEYWORDS.items():
+        if keyword in goal_lower:
+            result["platform"] = platform
+            break
+
+    return result

--- a/src/embodied_ai_architect/qualification/qualifier.py
+++ b/src/embodied_ai_architect/qualification/qualifier.py
@@ -169,6 +169,11 @@ class GoalQualifier:
         """
         self._original_goal = goal
 
+        # Parse numeric constraints from the goal string *before* any
+        # tangibility checks so that "30fps under 5W" is reflected in
+        # the scorecard immediately (BUG-006 / #164).
+        self._parse_goal_constraints(goal)
+
         # Detect or set domain
         if domain:
             self._domain = domain
@@ -421,6 +426,24 @@ class GoalQualifier:
     # -------------------------------------------------------------------
     # Private
     # -------------------------------------------------------------------
+
+    def _parse_goal_constraints(self, goal: str) -> None:
+        """Extract numeric constraints from the goal string and merge
+        them into ``_spec_fields`` so that tangibility is non-zero even
+        before the Q&A loop begins (BUG-006 / #164).
+        """
+        from embodied_ai_architect.mission.goal_parser import parse_goal_constraints
+
+        parsed = parse_goal_constraints(goal)
+
+        if "power_watts" in parsed:
+            self._merge_implications({"power.compute_power_watts": parsed["power_watts"]})
+        if "latency_ms" in parsed:
+            self._merge_implications({"perception.max_latency_ms": parsed["latency_ms"]})
+        if "cost_usd" in parsed:
+            self._merge_implications({"cost.target_cost_usd": parsed["cost_usd"]})
+        if "platform" in parsed and self._domain is None:
+            self._domain = parsed["platform"]
 
     def _build_result(self) -> QualificationResult:
         """Build a QualificationResult from current state."""

--- a/tests/test_registry_cli_commands.py
+++ b/tests/test_registry_cli_commands.py
@@ -110,8 +110,8 @@ class TestSensorSelect:
         mission, _ = empty_mission
         runner = CliRunner()
         result = runner.invoke(sensor, ["select", mission.id, "nonexistent.sensor"], obj={})
-        assert result.exit_code == 0
-        assert "not found in registry" in result.output
+        assert result.exit_code != 0
+        assert "not found" in result.output
 
 
 class TestSensorBudget:
@@ -203,8 +203,8 @@ class TestActuatorSelect:
         mission, _ = empty_mission
         runner = CliRunner()
         result = runner.invoke(actuator, ["select", mission.id, "nonexistent.actuator"], obj={})
-        assert result.exit_code == 0
-        assert "not found in registry" in result.output
+        assert result.exit_code != 0
+        assert "not found" in result.output
 
 
 class TestActuatorBudget:


### PR DESCRIPTION
## Summary
- **BUG-006 (#164)**: `GoalQualifier.assess()` now calls `_parse_goal_constraints()` before tangibility scoring, so a goal like "Drone perception SoC for YOLO at 30fps under 5W" immediately shows non-zero tangibility instead of 0%.
- **BUG-007 (#165)**: `mission new` parses the goal string via shared `goal_parser.py` and stores extracted constraints (power, latency, cost) on the Mission entity, so `design validate` finds them.
- **BUG-008 (#166)**: `sensor select` and `actuator select` exit with code 1 when all requested items are skipped (none found in registry) instead of silently exiting 0.

New shared module: `src/embodied_ai_architect/mission/goal_parser.py` — regex-based extraction of numeric targets and platform keywords from natural-language goal strings.

## Test plan
- [x] `tests/test_mission_cli.py` — 7 passed
- [x] `tests/test_sensor_cli.py` — 11 passed
- [x] `tests/test_actuator_cli.py` — 10 passed
- [x] `tests/test_design_cli.py` — 4 passed
- [x] `tests/test_registry_cli_commands.py` — updated nonexistent select tests to expect exit 1
- [x] Full lint gate: black + ruff clean
- [x] Full test suite: 1713 passed, 45 skipped (pre-existing errors/failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Goal descriptions now automatically extract performance constraints (power consumption, latency, and cost limits) from natural language text.
  * Platform type is now inferred from goal descriptions when not explicitly specified.

* **Bug Fixes**
  * Sensor and actuator selection commands now properly report failure with non-zero exit status when no requested items are successfully added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->