### PR TITLE
feat(llm): dynamic hardware catalog + profile-aliased SKUs (graphs#136 Phase 5)

### DIFF
--- a/src/embodied_ai_architect/llm/graphs_tools.py
+++ b/src/embodied_ai_architect/llm/graphs_tools.py
@@ -6,11 +6,11 @@ Provides LLM-callable tools for:
 - Bottleneck identification
 - Energy/power estimation
 
-Verdict-first tools (NEW):
-- analyze_latency: Check if model meets latency target
-- analyze_power: Check if model meets power budget
-- analyze_memory: Check if model fits in memory
-- check_constraint: Generic constraint checking
+Verdict-first tools:
+- check_latency: Check if model meets latency target
+- check_power: Check if model meets power budget
+- check_memory: Check if model fits in memory
+- full_analysis: Comprehensive analysis with optional constraint check
 """
 
 import json
@@ -66,35 +66,40 @@ except ImportError:
 # the synthetic "profile_aliases" bucket used when expanded.
 
 # Fallback minimal catalog for environments where graphs isn't installed.
-# Mirrors the registry as of this commit; see _get_hardware_catalog
-# below for the live source-of-truth path.
+# Keys MUST match the registry's canonical category names so a query
+# like list_available_hardware(category="gpu") returns a populated
+# bucket in fallback mode, not an "Unknown category" error. The live
+# registry uses: gpu / cpu / tpu / dsp / kpu / dpu / cgra / accelerator
+# / dfm. (Pre-Phase-5 this dict used datacenter_gpu / edge_gpu /
+# accelerators / automotive -- all of which would 404 against the live
+# resolver.)
 _FALLBACK_HARDWARE_CATALOG = {
-    "datacenter_gpu": [
-        "H100-SXM5-80GB",
-        "H100-PCIe-80GB",
+    "gpu": [
         "A100-SXM4-80GB",
         "B100-SXM6-192GB",
-        "V100-SXM3-32GB",
-        "T4-PCIe-16GB",
-    ],
-    "edge_gpu": [
+        "H100-PCIe-80GB",
+        "H100-SXM5-80GB",
         "Jetson-Orin-AGX-64GB",
         "Jetson-Orin-NX-16GB",
         "Jetson-Orin-Nano-8GB",
         "Jetson-Thor-128GB",
+        "T4-PCIe-16GB",
+        "V100-SXM3-32GB",
     ],
     "tpu": [
-        "TPU-v4",
         "Coral-Edge-TPU",
+        "TPU-v4",
     ],
-    "accelerators": [
-        "Stillwater-KPU-T256",
+    "kpu": [
         "Stillwater-KPU-T64",
+        "Stillwater-KPU-T256",
+    ],
+    "accelerator": [
         "Hailo-8",
     ],
-    "automotive": [
-        "TI-TDA4VM",
+    "dsp": [
         "TI-TDA4VL",
+        "TI-TDA4VM",
     ],
 }
 
@@ -364,7 +369,11 @@ def get_graphs_tool_definitions() -> list[dict[str, Any]]:
                     },
                     "hardware_name": {
                         "type": "string",
-                        "description": "Hardware target (e.g., 'H100', 'Jetson-Orin-AGX')",
+                        "description": (
+                            "Hardware target. Silicon-bin name or "
+                            "'<silicon>@<profile>' alias (see "
+                            "analyze_model_detailed for full description)."
+                        ),
                     },
                     "latency_target_ms": {
                         "type": "number",
@@ -592,13 +601,16 @@ def compare_hardware_targets(
     if error:
         return error
 
-    # Default hardware set for comparison
+    # Default hardware set for comparison. Names match the graphs
+    # registry (post-graphs#136 Phase 5) so each entry resolves cleanly
+    # in the analyzer; pre-Phase-5 the bare "Jetson-Orin-AGX" /
+    # "Jetson-Orin-Nano" names didn't.
     if hardware_targets is None:
         hardware_targets = [
             "H100-SXM5-80GB",
             "A100-SXM4-80GB",
-            "Jetson-Orin-AGX",
-            "Jetson-Orin-Nano",
+            "Jetson-Orin-AGX-64GB",
+            "Jetson-Orin-Nano-8GB",
             "TPU-v4",
             "Coral-Edge-TPU",
         ]

--- a/src/embodied_ai_architect/llm/graphs_tools.py
+++ b/src/embodied_ai_architect/llm/graphs_tools.py
@@ -48,46 +48,118 @@ except ImportError:
     GraphAnalysisResult = None
 
 
-# Hardware categories for easier discovery
-HARDWARE_CATALOG = {
+# Hardware catalog -- previously a hardcoded dict that drifted from the
+# graphs/ registry (e.g., "Jetson-Orin-AGX" without "-64GB", "V100-SXM2-32GB"
+# vs the registry's "V100-SXM3-32GB"). Phase 5 of branes-ai/graphs#136
+# replaces it with a dynamic lookup against ``graphs.hardware.mappers``.
+#
+# Two-tier display:
+# - Default ("silicon" view): silicon-bin SKUs only. Manageable size for
+#   LLM consumption (~46 today). What the orchestrator usually needs.
+# - Expanded ("all" view, opt-in): silicon-bins + power-profile aliases
+#   (e.g., "Jetson-Orin-Nano-8GB@7W"). What an embodied-AI workflow
+#   reasoning about deployment targets needs once a power envelope has
+#   been chosen.
+#
+# Categories come from the registry's ``category`` metadata
+# (gpu / cpu / tpu / dsp / kpu / dpu / cgra / accelerator / dfm) plus
+# the synthetic "profile_aliases" bucket used when expanded.
+
+# Fallback minimal catalog for environments where graphs isn't installed.
+# Mirrors the registry as of this commit; see _get_hardware_catalog
+# below for the live source-of-truth path.
+_FALLBACK_HARDWARE_CATALOG = {
     "datacenter_gpu": [
         "H100-SXM5-80GB",
+        "H100-PCIe-80GB",
         "A100-SXM4-80GB",
-        "A100-SXM4-40GB",
-        "V100-SXM2-32GB",
-        "L4",
-        "T4",
+        "B100-SXM6-192GB",
+        "V100-SXM3-32GB",
+        "T4-PCIe-16GB",
     ],
     "edge_gpu": [
-        "Jetson-Orin-AGX",
-        "Jetson-Orin-Nano",
-    ],
-    "datacenter_cpu": [
-        "Intel-Xeon-8490H",
-        "AMD-EPYC-9654",
-    ],
-    "edge_cpu": [
-        "Intel-i7-12700K",
+        "Jetson-Orin-AGX-64GB",
+        "Jetson-Orin-NX-16GB",
+        "Jetson-Orin-Nano-8GB",
+        "Jetson-Thor-128GB",
     ],
     "tpu": [
         "TPU-v4",
         "Coral-Edge-TPU",
     ],
     "accelerators": [
-        "KPU-T256",
-        "KPU-T64",
+        "Stillwater-KPU-T256",
+        "Stillwater-KPU-T64",
         "Hailo-8",
     ],
     "automotive": [
-        "TDA4VM",
-        "TDA4VL",
+        "TI-TDA4VM",
+        "TI-TDA4VL",
     ],
 }
 
-# Flatten for quick lookup
-ALL_HARDWARE = []
-for category, hw_list in HARDWARE_CATALOG.items():
-    ALL_HARDWARE.extend(hw_list)
+
+def _get_hardware_catalog(include_profile_aliases: bool = False) -> dict[str, list[str]]:
+    """Return the live hardware catalog grouped by category.
+
+    Sources from ``graphs.hardware.mappers`` when graphs is installed,
+    so the orchestrator's hardware list always matches what the
+    estimators can actually accept. Falls back to the static
+    ``_FALLBACK_HARDWARE_CATALOG`` when graphs isn't available -- this
+    keeps EAA usable for non-analysis flows even without the optional
+    schemas/graphs deps.
+
+    With ``include_profile_aliases=True``, surfaces power-profile aliases
+    (e.g., ``"Jetson-Orin-Nano-8GB@7W"``) alongside their silicon-bin
+    parents. The orchestrator uses the expanded form when reasoning
+    about deployment targets where power envelope is a first-class
+    decision variable -- per branes-ai/graphs#136 Phase 5.
+    """
+    if not HAS_GRAPHS:
+        return _FALLBACK_HARDWARE_CATALOG
+
+    try:
+        from graphs.hardware.mappers import (
+            list_all_mappers,
+            list_all_skus,
+            get_mapper_info,
+        )
+    except ImportError:
+        return _FALLBACK_HARDWARE_CATALOG
+
+    # Build silicon-bin -> category lookup once.
+    silicon_to_category: dict[str, str] = {}
+    for silicon_name in list_all_mappers():
+        info = get_mapper_info(silicon_name)
+        if info is not None:
+            silicon_to_category[silicon_name] = info["category"]
+
+    catalog: dict[str, list[str]] = {}
+    if include_profile_aliases:
+        # list_all_skus returns silicon-bins + profile aliases. Each
+        # alias inherits its silicon-bin's category.
+        for sku in list_all_skus():
+            silicon = sku.split("@", 1)[0]
+            category = silicon_to_category.get(silicon, "unknown")
+            catalog.setdefault(category, []).append(sku)
+    else:
+        for silicon, category in silicon_to_category.items():
+            catalog.setdefault(category, []).append(silicon)
+
+    # Stable ordering: sorted within each category so LLM output is
+    # deterministic across calls.
+    for entries in catalog.values():
+        entries.sort()
+    return catalog
+
+
+# Flat list -- computed on first access via _get_hardware_catalog. Kept
+# as a module-level name for backward compatibility with any consumer
+# that imported ALL_HARDWARE / HARDWARE_CATALOG directly.
+HARDWARE_CATALOG = _get_hardware_catalog(include_profile_aliases=False)
+ALL_HARDWARE: list[str] = []
+for _hw_list in HARDWARE_CATALOG.values():
+    ALL_HARDWARE.extend(_hw_list)
 
 
 def get_graphs_tool_definitions() -> list[dict[str, Any]]:
@@ -118,8 +190,18 @@ def get_graphs_tool_definitions() -> list[dict[str, Any]]:
                     "hardware_name": {
                         "type": "string",
                         "description": (
-                            "Hardware target (e.g., 'H100-SXM5-80GB', 'Jetson-Orin-AGX', "
-                            "'TPU-v4', 'Coral-Edge-TPU', 'KPU-T256')"
+                            "Hardware target. Either a silicon-bin name "
+                            "(e.g., 'H100-SXM5-80GB', 'Jetson-Orin-Nano-8GB', "
+                            "'TPU-v4', 'Coral-Edge-TPU', 'Stillwater-KPU-T256') "
+                            "or a power-profile alias of the form "
+                            "'<silicon>@<profile>' (e.g., "
+                            "'Jetson-Orin-Nano-8GB@7W' for the 7W nvpmodel mode, "
+                            "'Jetson-Orin-AGX-64GB@30W'). The alias form is "
+                            "preferred for embodied-AI deployment analysis when "
+                            "the power envelope is part of the deployment "
+                            "decision. Use list_available_hardware "
+                            "(include_profile_aliases=true) to enumerate "
+                            "available aliases."
                         ),
                     },
                     "batch_size": {
@@ -153,7 +235,14 @@ def get_graphs_tool_definitions() -> list[dict[str, Any]]:
                         "type": "array",
                         "items": {"type": "string"},
                         "description": (
-                            "List of hardware targets to compare. If not specified, "
+                            "List of hardware targets to compare. Each entry is "
+                            "either a silicon-bin name (e.g., 'H100-SXM5-80GB') "
+                            "or a power-profile alias "
+                            "('Jetson-Orin-Nano-8GB@7W'). For embodied-AI "
+                            "deployment comparisons, mixing profiles of the "
+                            "same silicon (e.g., '@7W', '@15W', '@MAXN') is a "
+                            "natural way to surface the power/performance "
+                            "trade-off on a single chip. If not specified, "
                             "uses a default set of representative hardware."
                         ),
                     },
@@ -181,7 +270,7 @@ def get_graphs_tool_definitions() -> list[dict[str, Any]]:
                     },
                     "hardware_name": {
                         "type": "string",
-                        "description": "Hardware target",
+                        "description": "Hardware target. Silicon-bin name or '<silicon>@<profile>' alias (see analyze_model_detailed for full description).",
                     },
                     "batch_size": {
                         "type": "integer",
@@ -194,25 +283,36 @@ def get_graphs_tool_definitions() -> list[dict[str, Any]]:
         {
             "name": "list_available_hardware",
             "description": (
-                "List all available hardware targets for analysis, organized by category "
-                "(datacenter GPU, edge GPU, CPU, TPU, accelerators, automotive)."
+                "List all available hardware targets for analysis, organized by "
+                "category (gpu, cpu, tpu, dsp, kpu, dpu, cgra, accelerator, dfm). "
+                "Categories come live from the graphs registry, so the list always "
+                "matches what the analysis tools can actually accept. By default "
+                "returns silicon-bin names (e.g. 'Jetson-Orin-Nano-8GB'). Set "
+                "include_profile_aliases=true to also surface power-profile aliases "
+                "(e.g. 'Jetson-Orin-Nano-8GB@7W' / '@15W' / '@MAXN'); these are the "
+                "right form for embodied-AI deployment recommendations where the "
+                "power envelope is part of the SKU decision."
             ),
             "input_schema": {
                 "type": "object",
                 "properties": {
                     "category": {
                         "type": "string",
-                        "enum": [
-                            "all",
-                            "datacenter_gpu",
-                            "edge_gpu",
-                            "datacenter_cpu",
-                            "edge_cpu",
-                            "tpu",
-                            "accelerators",
-                            "automotive",
-                        ],
-                        "description": "Filter by category (default: all)",
+                        "description": (
+                            "Filter to a single category from the registry "
+                            "(e.g. 'gpu', 'cpu', 'tpu', 'kpu', 'accelerator'). "
+                            "Default 'all' returns every category."
+                        ),
+                    },
+                    "include_profile_aliases": {
+                        "type": "boolean",
+                        "description": (
+                            "When true, surface power-profile aliases of the form "
+                            "'<silicon>@<profile>' (e.g. 'Jetson-Orin-AGX-64GB@30W') "
+                            "alongside the silicon-bin names. Use this when the "
+                            "user is selecting a deployment target and power "
+                            "envelope matters. Default false (silicon-bin only)."
+                        ),
                     },
                 },
                 "required": [],
@@ -233,7 +333,7 @@ def get_graphs_tool_definitions() -> list[dict[str, Any]]:
                     },
                     "hardware_name": {
                         "type": "string",
-                        "description": "Hardware target",
+                        "description": "Hardware target. Silicon-bin name or '<silicon>@<profile>' alias (see analyze_model_detailed for full description).",
                     },
                     "batch_size": {
                         "type": "integer",
@@ -299,7 +399,7 @@ def get_graphs_tool_definitions() -> list[dict[str, Any]]:
                     },
                     "hardware_name": {
                         "type": "string",
-                        "description": "Hardware target",
+                        "description": "Hardware target. Silicon-bin name or '<silicon>@<profile>' alias (see analyze_model_detailed for full description).",
                     },
                     "power_budget_w": {
                         "type": "number",
@@ -329,7 +429,7 @@ def get_graphs_tool_definitions() -> list[dict[str, Any]]:
                     },
                     "hardware_name": {
                         "type": "string",
-                        "description": "Hardware target",
+                        "description": "Hardware target. Silicon-bin name or '<silicon>@<profile>' alias (see analyze_model_detailed for full description).",
                     },
                     "memory_budget_mb": {
                         "type": "number",
@@ -359,7 +459,7 @@ def get_graphs_tool_definitions() -> list[dict[str, Any]]:
                     },
                     "hardware_name": {
                         "type": "string",
-                        "description": "Hardware target",
+                        "description": "Hardware target. Silicon-bin name or '<silicon>@<profile>' alias (see analyze_model_detailed for full description).",
                     },
                     "constraint_metric": {
                         "type": "string",
@@ -699,22 +799,36 @@ def _interpret_bottleneck(bottleneck_type: "BottleneckType", roofline) -> str:
         )
 
 
-def list_available_hardware(category: str = "all") -> str:
-    """List available hardware targets by category."""
+def list_available_hardware(
+    category: str = "all", include_profile_aliases: bool = False
+) -> str:
+    """List available hardware targets by category.
+
+    Live-sources from ``graphs.hardware.mappers`` so the list always
+    matches the analysis tools' actual hardware support. Set
+    ``include_profile_aliases=True`` to surface power-profile SKUs
+    (e.g. ``"Jetson-Orin-Nano-8GB@7W"``) alongside silicon-bin names --
+    these are the right form for embodied-AI deployment recommendations.
+    """
+    catalog = _get_hardware_catalog(include_profile_aliases=include_profile_aliases)
+    total = sum(len(entries) for entries in catalog.values())
+
     if category == "all":
-        output = {
-            "total_hardware_targets": len(ALL_HARDWARE),
-            "categories": HARDWARE_CATALOG,
+        output: dict[str, Any] = {
+            "total_hardware_targets": total,
+            "include_profile_aliases": include_profile_aliases,
+            "categories": catalog,
         }
-    elif category in HARDWARE_CATALOG:
+    elif category in catalog:
         output = {
             "category": category,
-            "hardware": HARDWARE_CATALOG[category],
+            "include_profile_aliases": include_profile_aliases,
+            "hardware": catalog[category],
         }
     else:
         output = {
             "error": f"Unknown category: {category}",
-            "available_categories": list(HARDWARE_CATALOG.keys()),
+            "available_categories": sorted(catalog.keys()),
         }
 
     return json.dumps(output, indent=2)

--- a/src/embodied_ai_architect/llm/graphs_tools.py
+++ b/src/embodied_ai_architect/llm/graphs_tools.py
@@ -799,9 +799,7 @@ def _interpret_bottleneck(bottleneck_type: "BottleneckType", roofline) -> str:
         )
 
 
-def list_available_hardware(
-    category: str = "all", include_profile_aliases: bool = False
-) -> str:
+def list_available_hardware(category: str = "all", include_profile_aliases: bool = False) -> str:
     """List available hardware targets by category.
 
     Live-sources from ``graphs.hardware.mappers`` so the list always

--- a/tests/test_hardware_catalog.py
+++ b/tests/test_hardware_catalog.py
@@ -140,3 +140,39 @@ class TestFallbackCatalog:
         flat = [sku for entries in _FALLBACK_HARDWARE_CATALOG.values() for sku in entries]
         assert "Jetson-Orin-Nano-8GB" in flat
         assert "Jetson-Orin-AGX-64GB" in flat
+
+    def test_fallback_catalog_keys_match_registry_categories(self):
+        # Regression guard: the fallback's keys MUST be the registry's
+        # canonical category names (gpu / tpu / kpu / accelerator / dsp
+        # / etc.), NOT the legacy "datacenter_gpu" / "edge_gpu" /
+        # "accelerators" / "automotive" buckets the orchestrator used
+        # pre-Phase-5. Otherwise list_available_hardware(category="gpu")
+        # returns "Unknown category" in fallback mode, which is exactly
+        # the failure CodeRabbit caught on PR #201.
+        legacy_keys = {"datacenter_gpu", "edge_gpu", "accelerators", "automotive"}
+        actual_keys = set(_FALLBACK_HARDWARE_CATALOG.keys())
+        assert legacy_keys.isdisjoint(actual_keys), (
+            f"Fallback catalog still uses legacy category keys "
+            f"{actual_keys & legacy_keys}; should use registry-canonical "
+            f"names like 'gpu'."
+        )
+        # Sanity: at minimum, 'gpu' and 'tpu' are present.
+        assert "gpu" in actual_keys
+        assert "tpu" in actual_keys
+
+    def test_list_available_hardware_in_fallback_mode(self, monkeypatch):
+        # Whole-tool round-trip in fallback mode: when graphs is
+        # unavailable, list_available_hardware(category="gpu") must
+        # return a populated bucket, not the "Unknown category" error
+        # payload. This is what CodeRabbit's Major finding on PR #201
+        # caught -- before the fallback-key fix, the tool would 404 on
+        # the most common LLM query.
+        from embodied_ai_architect.llm import graphs_tools as gt
+
+        monkeypatch.setattr(gt, "HAS_GRAPHS", False)
+        result = json.loads(gt.list_available_hardware(category="gpu"))
+        assert (
+            "error" not in result
+        ), f"Expected populated gpu bucket in fallback mode, got: {result}"
+        assert result["category"] == "gpu"
+        assert len(result["hardware"]) > 0

--- a/tests/test_hardware_catalog.py
+++ b/tests/test_hardware_catalog.py
@@ -78,9 +78,9 @@ class TestDynamicHardwareCatalog:
         # avoids triggering spurious cache misses in prompt caches.
         catalog = _get_hardware_catalog(include_profile_aliases=False)
         for category, entries in catalog.items():
-            assert entries == sorted(entries), (
-                f"Category {category!r} entries not sorted: {entries}"
-            )
+            assert entries == sorted(
+                entries
+            ), f"Category {category!r} entries not sorted: {entries}"
 
 
 @pytest.mark.skipif(not HAS_GRAPHS, reason="graphs package not installed")
@@ -107,9 +107,7 @@ class TestListAvailableHardwareTool:
         assert any("Jetson-Orin" in sku for sku in result["hardware"])
 
     def test_category_filter_with_aliases(self):
-        result = json.loads(
-            list_available_hardware(category="gpu", include_profile_aliases=True)
-        )
+        result = json.loads(list_available_hardware(category="gpu", include_profile_aliases=True))
         # Profile aliases now visible in the gpu bucket.
         assert any("@" in sku for sku in result["hardware"])
 

--- a/tests/test_hardware_catalog.py
+++ b/tests/test_hardware_catalog.py
@@ -1,0 +1,144 @@
+"""Tests for the dynamic hardware catalog (graphs#136 Phase 5).
+
+Locks in the contract that ``list_available_hardware`` and the
+``HARDWARE_CATALOG`` / ``ALL_HARDWARE`` module-level names live-source
+from ``graphs.hardware.mappers`` so the orchestrator's hardware list
+always matches what the analysis tools can actually accept.
+
+Skipped when graphs isn't installed in the test environment -- the
+fallback path is exercised separately.
+"""
+
+import json
+
+import pytest
+
+from embodied_ai_architect.llm.graphs_tools import (
+    HAS_GRAPHS,
+    _FALLBACK_HARDWARE_CATALOG,
+    _get_hardware_catalog,
+    list_available_hardware,
+)
+
+
+@pytest.mark.skipif(not HAS_GRAPHS, reason="graphs package not installed")
+class TestDynamicHardwareCatalog:
+    """Live-source path: graphs is available, catalog comes from the
+    registry. These tests cover the happy path plus the profile-alias
+    expansion that Phase 5 of branes-ai/graphs#136 added."""
+
+    def test_default_catalog_is_silicon_bins_only(self):
+        catalog = _get_hardware_catalog(include_profile_aliases=False)
+        # No alias entries (those contain '@').
+        for entries in catalog.values():
+            for sku in entries:
+                assert "@" not in sku
+
+    def test_default_catalog_has_real_jetson_names(self):
+        # Regression guard for the pre-Phase-5 catalog drift, where
+        # 'Jetson-Orin-AGX' (without size) and 'V100-SXM2-32GB' were
+        # listed -- neither matches the graphs registry.
+        catalog = _get_hardware_catalog(include_profile_aliases=False)
+        gpu = catalog.get("gpu", [])
+        assert "Jetson-Orin-AGX-64GB" in gpu
+        assert "Jetson-Orin-Nano-8GB" in gpu
+        assert "Jetson-Orin-NX-16GB" in gpu
+
+    def test_expanded_catalog_includes_profile_aliases(self):
+        catalog = _get_hardware_catalog(include_profile_aliases=True)
+        flat = [sku for entries in catalog.values() for sku in entries]
+        # Orin Nano's 4 modes (7W / 15W / 25W / MAXN per graphs#136
+        # Phase 1) all surface in the expanded view.
+        assert "Jetson-Orin-Nano-8GB@7W" in flat
+        assert "Jetson-Orin-Nano-8GB@15W" in flat
+        assert "Jetson-Orin-Nano-8GB@25W" in flat
+        assert "Jetson-Orin-Nano-8GB@MAXN" in flat
+
+    def test_expanded_catalog_has_more_entries_than_default(self):
+        default = _get_hardware_catalog(include_profile_aliases=False)
+        expanded = _get_hardware_catalog(include_profile_aliases=True)
+        d_count = sum(len(v) for v in default.values())
+        e_count = sum(len(v) for v in expanded.values())
+        # Every silicon-bin contributes >= 1 entry to expanded; chips
+        # with multiple thermal_operating_points contribute more. So
+        # expanded must be strictly larger.
+        assert e_count > d_count
+
+    def test_aliases_inherit_silicon_category(self):
+        # An alias of a 'gpu' silicon (e.g., Jetson-Orin-Nano-8GB) must
+        # also be classified under 'gpu' -- the alias mechanism doesn't
+        # invent new categories. Regression guard against the bucket
+        # logic in _get_hardware_catalog.
+        catalog = _get_hardware_catalog(include_profile_aliases=True)
+        gpu = catalog.get("gpu", [])
+        assert "Jetson-Orin-Nano-8GB@7W" in gpu
+
+    def test_categories_are_sorted_for_determinism(self):
+        # LLM consumes the JSON output -- stable ordering across runs
+        # avoids triggering spurious cache misses in prompt caches.
+        catalog = _get_hardware_catalog(include_profile_aliases=False)
+        for category, entries in catalog.items():
+            assert entries == sorted(entries), (
+                f"Category {category!r} entries not sorted: {entries}"
+            )
+
+
+@pytest.mark.skipif(not HAS_GRAPHS, reason="graphs package not installed")
+class TestListAvailableHardwareTool:
+    """The LLM-callable wrapper around _get_hardware_catalog."""
+
+    def test_default_call_returns_silicon_bins_only(self):
+        result = json.loads(list_available_hardware())
+        assert result["include_profile_aliases"] is False
+        # Every entry across categories is a silicon-bin name (no '@').
+        for entries in result["categories"].values():
+            assert all("@" not in sku for sku in entries)
+
+    def test_include_profile_aliases_flag_expands(self):
+        bare = json.loads(list_available_hardware())
+        expanded = json.loads(list_available_hardware(include_profile_aliases=True))
+        assert expanded["include_profile_aliases"] is True
+        assert expanded["total_hardware_targets"] > bare["total_hardware_targets"]
+
+    def test_category_filter_for_gpu_returns_jetsons(self):
+        result = json.loads(list_available_hardware(category="gpu"))
+        assert result["category"] == "gpu"
+        # At least one Jetson present.
+        assert any("Jetson-Orin" in sku for sku in result["hardware"])
+
+    def test_category_filter_with_aliases(self):
+        result = json.loads(
+            list_available_hardware(category="gpu", include_profile_aliases=True)
+        )
+        # Profile aliases now visible in the gpu bucket.
+        assert any("@" in sku for sku in result["hardware"])
+
+    def test_unknown_category_returns_clear_error(self):
+        result = json.loads(list_available_hardware(category="not-a-category"))
+        assert "error" in result
+        assert "available_categories" in result
+
+
+class TestFallbackCatalog:
+    """When ``graphs`` isn't available, ``_get_hardware_catalog`` returns
+    the static fallback. Test that path independently of HAS_GRAPHS so
+    it runs regardless of the test environment's optional-dep state.
+
+    We do this by patching the HAS_GRAPHS flag in the module, since
+    the function checks it lazily.
+    """
+
+    def test_fallback_catalog_used_when_graphs_unavailable(self, monkeypatch):
+        from embodied_ai_architect.llm import graphs_tools as gt
+
+        monkeypatch.setattr(gt, "HAS_GRAPHS", False)
+        result = gt._get_hardware_catalog()
+        # Returns the fallback verbatim (same dict identity).
+        assert result is gt._FALLBACK_HARDWARE_CATALOG
+
+    def test_fallback_catalog_has_real_jetson_names(self):
+        # Even the fallback uses the registry-correct names so users
+        # don't get a confusingly-different list when graphs is missing.
+        flat = [sku for entries in _FALLBACK_HARDWARE_CATALOG.values() for sku in entries]
+        assert "Jetson-Orin-Nano-8GB" in flat
+        assert "Jetson-Orin-AGX-64GB" in flat


### PR DESCRIPTION
## Summary

Phase 5 of [branes-ai/graphs#136](https://github.com/branes-ai/graphs/issues/136). Replaces the hardcoded `HARDWARE_CATALOG` in `graphs_tools.py` with a live-source lookup against `graphs.hardware.mappers`. The orchestrator's hardware list now always matches what the analysis tools can actually accept, and the LLM can address power-profile SKUs the same way the graphs registry does.

## Why now

The previous static `HARDWARE_CATALOG` had drifted from the graphs registry — `"Jetson-Orin-AGX"` (without `-64GB` suffix), `"V100-SXM2-32GB"` (registry has `V100-SXM3-32GB`), `"TDA4VM"` (registry has `TI-TDA4VM`), etc. The LLM was being told these names worked for analysis when they don't.

Phase 5 of the embodied-AI deployment-targeting arc closes this by making the orchestrator's hardware surface a thin proxy over the registry, with **opt-in profile-alias expansion** for embodied-AI deployment workflows.

## What changed

### `_get_hardware_catalog()` — new dynamic lookup

```python
catalog = _get_hardware_catalog(include_profile_aliases=True)
# {'gpu': ['Jetson-Orin-Nano-8GB', 'Jetson-Orin-Nano-8GB@7W',
#          'Jetson-Orin-Nano-8GB@15W', 'Jetson-Orin-Nano-8GB@25W',
#          'Jetson-Orin-Nano-8GB@MAXN', 'Jetson-Orin-AGX-64GB', ...],
#  'cpu': [...], ...}
```

- Sources from `graphs.hardware.mappers.list_all_mappers()` and `list_all_skus()` at call time.
- Groups by registry category (gpu, cpu, tpu, kpu, accelerator, dsp, dpu, cgra, dfm).
- With `include_profile_aliases=True`, surfaces `<silicon>@<profile>` aliases alongside silicon-bin names.
- Sorts entries within each category for deterministic LLM output (preserves prompt-cache hits).
- Falls back to a static `_FALLBACK_HARDWARE_CATALOG` (also using registry-correct names) when graphs isn't installed — keeps EAA usable without the optional schemas/graphs deps.

### `list_available_hardware` tool

Gained an `include_profile_aliases: bool` parameter (default `false`). The tool description explains both views and points the LLM at the profile-alias form for embodied-AI deployment recommendations:

> By default returns silicon-bin names. Set `include_profile_aliases=true` to also surface power-profile aliases (e.g. `'Jetson-Orin-Nano-8GB@7W'` / `'@15W'` / `'@MAXN'`); these are the right form for embodied-AI deployment recommendations where the power envelope is part of the SKU decision.

### `analyze_model_detailed` / `compare_hardware_targets`

The `hardware_name` parameter description now documents the alias form and recommends it for embodied-AI workflows. Other tools' bare `"Hardware target"` descriptions point readers at `analyze_model_detailed` for the canonical doc.

### Concrete result on today's registry

| View | Total entries |
|---|---|
| Silicon-bin only (default) | 46 |
| With profile aliases | 123 |

Worked example for Orin Nano:
```
Jetson-Orin-Nano-8GB        (default profile, 15W)
Jetson-Orin-Nano-8GB@7W     (battery deployment)
Jetson-Orin-Nano-8GB@15W    (Super, edge AI baseline)
Jetson-Orin-Nano-8GB@25W    (production cap with DVFS)
Jetson-Orin-Nano-8GB@MAXN   (developer/burst, DVFS off)
```

## Test plan

- [x] `tests/test_hardware_catalog.py` — 13 new tests:
  - Default catalog returns silicon-bins only; expanded view includes profile aliases
  - Real Jetson names (`Jetson-Orin-AGX-64GB`, `-NX-16GB`, `-Nano-8GB`) present (regression guard for the pre-Phase-5 drift)
  - All 4 Orin Nano modes (7W / 15W / 25W / MAXN) surface in expanded view
  - Aliases inherit silicon-bin category (no synthetic categories)
  - Categories sorted within each bucket (prompt-cache friendly)
  - `list_available_hardware` tool: default + alias-expansion + category filter + unknown-category error path
  - Fallback path tested independently (monkeypatch `HAS_GRAPHS=False`)
- [x] Local sweep: 13 pass / 27 skipped (integration tests). No regressions.
- [ ] CI passes
- [ ] Promote when satisfied: `gh pr ready NNN`

## Cross-repo tracking

- `branes-ai/graphs#136` (umbrella) — Phase 5 (this PR is the cross-repo consumer-side change)
- Phase 1: graphs PR #137 (merged) — registry alias addressability
- Phase 2: graphs PR #138 (merged) — `--profiles all` + Mode/clock columns
- Phase 3: graphs PR #139 (merged) — memory_type / memory_bus_width_bits
- Phase 3.5: graphs PR #141 (merged) — YAML loader + validator
- Phase 4: graphs PR #142 (merged) — memory_clock_mhz per profile

After this PR lands, the graphs#136 umbrella issue can be closed: the cross-repo arc is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added verdict-first analysis tools for checking latency, power, memory, and full hardware analysis.
  * Hardware catalog is now built dynamically from the live registry and supports power-profile alias variants.
  * Hardware listing supports category filtering and optional expansion to include profile aliases.

* **Tests**
  * Added comprehensive tests validating dynamic vs fallback hardware catalogs, alias expansion, deterministic ordering, and listing/error payloads.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/branes-ai/embodied-ai-architect/pull/201)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->