### PR TITLE
feat(graphs): Loop Convergence roadmap + DRAFT skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,10 @@ jobs:
           python-version: "3.11"
 
       - name: Install linters
-        run: pip install black ruff
+        # Pin to match the project's .venv (see pyproject dev extras) so CI is
+        # deterministic and does not drift onto a newer Black/Ruff that reformats
+        # files the committed, locally-linted tree considers clean.
+        run: pip install black==25.12.0 ruff==0.14.10
 
       - name: Black check
         run: black --check src/ tests/ --line-length 100

--- a/docs/plans/roadmap-loop-convergence.md
+++ b/docs/plans/roadmap-loop-convergence.md
@@ -1,0 +1,223 @@
+# Roadmap — Loop Convergence
+
+**Created:** 2026-07-09
+**Status:** Draft
+**Owner:** Architect team
+**Depends on:** `roadmap-v2.md` R0.8 (Optimization Loop), `agentic-optimization-loop.md` (Phases 1–4, all landed)
+**Slots between:** roadmap-v2 R0.8 → R0.9
+
+**Goal:** Turn the two existing, disjoint closed loops into a single unified multi-agent
+design loop where reasoning specialists, a critic, and an optimizer iterate over **one
+evolving design state** — the difference between "LLM-supervised search plus a
+human-driven CLI skill loop" (today) and "a proper loop-engineering multi-agent design
+automation system" (target).
+
+---
+
+## Why This Release Exists
+
+Phases 1–3 of `agentic-optimization-loop.md` are implemented and Phase 4's loop runs.
+But the system is **not yet one loop**. A code audit (2026-07-09) found three structural
+gaps that no current roadmap milestone addresses:
+
+1. **Two disjoint loops with two state schemas.**
+   - Population/Pareto MOO loop: `graphs/optimization_loop.py` over `OptimizationLoopState`
+     (decompose → formulate → optimize → evaluate → reason → {iterate | recommend}).
+   - Single-design dispatcher loop: `graphs/soc_graph.py` / `graphs/dispatcher.py` over
+     `SoCDesignState` (planner → dispatch → evaluate → {optimize → dispatch | report}).
+   - Neither shares design state with the other; the architect skills only target the latter.
+
+2. **The "specialists" are not agents.** In the dispatcher loop they are deterministic
+   estimator functions (`graphs/specialists.py`, `graphs/physical_estimators.py`), not
+   reasoning agents negotiating over shared state. Only the Phase-4 `reason_node` uses an LLM.
+
+3. **Feedback is shallow.** When the critic (`reason_node`) says "iterate," it emits coarse
+   moves (narrow the search, tighten a budget) and `optimize_node` just re-runs MAP-Elites
+   with iteration-scaled effort (`optimization_loop.py:352`). It does not translate insight
+   into concrete design-space edits or re-task specific specialists.
+
+4. **The best "loop" UX is human-in-the-CLI.** `architect-loop`, `architect-drill`, and
+   `architect-assess` read a real `SoCDesignState` via `branes session show --json`, but they
+   are markdown prompt-skills that shell out to the CLI — not code-invoked graph nodes.
+
+**Business value:** This is the credibility milestone. It is what lets us say the agent
+*designs*, not just *searches*. It is a prerequisite for the co-simulation trust story
+(roadmap-v2 R0.9) because a unified, inspectable design state is what co-sim validates against.
+
+---
+
+## Target Architecture
+
+```
+                        ┌────────────────────────────────┐
+                        │        Unified DesignState      │  ◄── one schema, one source of truth
+                        │  (constraints, artifacts, PPA,  │
+                        │   pareto, history, open_issues) │
+                        └───────────────┬────────────────┘
+                                        │  read / mutate
+        ┌───────────────┬───────────────┼───────────────┬───────────────┐
+        ▼               ▼               ▼               ▼               ▼
+  ┌──────────┐   ┌────────────┐  ┌────────────┐  ┌────────────┐  ┌────────────┐
+  │ Planner  │   │ Specialists│  │  Optimizer │  │   Critic   │  │  Architect │
+  │ (agent)  │   │ (agents +  │  │ (MOO engine│  │  (agent)   │  │   skills   │
+  │          │   │  estimator │  │  as a tool)│  │ emits      │  │ (CLI ->    │
+  │          │   │  tools)    │  │            │  │ design     │  │  graph     │
+  │          │   │            │  │            │  │ deltas)    │  │  iteration)│
+  └────┬─────┘   └─────┬──────┘  └─────┬──────┘  └─────┬──────┘  └─────┬──────┘
+       └───────────────┴───────────────┴───────────────┴───────────────┘
+                                        │
+                        ┌───────────────▼────────────────┐
+                        │      Convergence controller      │  ◄── one loop condition,
+                        │  (hypervolume Δ, issue backlog,  │      not two
+                        │   critic "diminishing returns")  │
+                        └──────────────────────────────────┘
+```
+
+The MOO engine stops being *the* loop and becomes a **tool the optimizer agent calls**.
+The physical estimators stop being *the* specialists and become **tools the specialist
+agents call**. The two state schemas collapse into one `DesignState`.
+
+---
+
+## Phase 1 — Unify the State
+
+**Goal:** One `DesignState` that both loops read and mutate; delete the schema seam.
+
+| # | Task | Priority | Effort |
+|---|------|----------|--------|
+| 1 | Define `DesignState` superset that subsumes `SoCDesignState` + `OptimizationLoopState` (design point, joint design space, pareto_points, pareto_frontier_history, moo_results, ppa_metrics, kpu_config, `open_issues`, history) | P0 | L |
+| 2 | Add `open_issues: list[DesignIssue]` — structured, typed bottleneck records (metric, level, contribution, severity, proposed action) — the shared currency between critic and optimizer | P0 | M |
+| 3 | Migrate `optimization_loop.py` nodes to read/write `DesignState` (keep the graph shape) | P0 | M |
+| 4 | Migrate `soc_graph.py` / `dispatcher.py` to the same `DesignState` | P0 | L |
+| 5 | Adapter/compat shims so existing snapshot builders, `/api/sessions/*`, and `branes session show` keep working | P1 | M |
+
+**Exit criteria:** A single `branes` session produces one `DesignState` that carries both the
+Pareto frontier and the single-design dispatcher artifacts; both graphs run against it; all
+existing MOO state-field consumers (per CLAUDE.md table) still resolve.
+
+---
+
+## Phase 2 — Agent-ify the Critic and the Optimizer
+
+**Goal:** Replace coarse "iterate" with structured, actionable feedback.
+
+| # | Task | Priority | Effort |
+|---|------|----------|--------|
+| 1 | Promote `reason_node` to a **Critic agent** that emits `DesignDelta` objects (design-space variable edits, constraint relaxations, specialist re-tasking) instead of a free-text "iterate" verdict | P0 | L |
+| 2 | Promote `design_optimizer` to an **Optimizer agent** that consumes `DesignDelta`s, edits the joint design space concretely, and calls the MOO engine **as a tool** (not as the loop body) | P0 | L |
+| 3 | Wire critic → `open_issues` → optimizer so each iteration closes specific issues rather than globally re-running MAP-Elites | P0 | M |
+| 4 | Keep a deterministic fallback path (no LLM key) for both agents — mirror the existing `_reason_with_llm` / heuristic-fallback pattern (`optimization_loop.py:507,576`) | P1 | M |
+| 5 | Cost + audit trail per agent turn (reuse existing token cost tracking + governance) | P1 | S |
+
+**Exit criteria:** Given a design that fails a constraint, the Critic emits ≥1 concrete
+`DesignDelta`, the Optimizer applies it as a specific design-space edit, and the next
+iteration's Pareto front reflects that edit — verifiable in `open_issues` closing out.
+
+---
+
+## Phase 3 — Specialists as Agents with Estimator Tools
+
+**Goal:** Turn 2–3 deterministic specialists into reasoning agents; keep the estimators as tools.
+
+| # | Task | Priority | Effort |
+|---|------|----------|--------|
+| 1 | Wrap `physical_estimators.py` / `specialists.py` functions as **callable tools** (verdict-first schema) | P0 | M |
+| 2 | Promote the **PPA/critic-adjacent specialist** and the **architecture composer** to agents that call those tools and reason over `open_issues` | P0 | L |
+| 3 | Leave pure-numeric specialists (thermal, cost, floorplan, bandwidth) as deterministic tools — do **not** agent-ify what has no judgment content | P1 | S |
+| 4 | KPU inner-loop specialists (`kpu_specialists.py`) stay deterministic but publish issues into the shared `open_issues` backlog | P2 | M |
+
+**Exit criteria:** At least two specialists reason over shared state and call estimator tools;
+their outputs land as `DesignIssue`s the critic and optimizer act on — no separate specialist
+state schema remains.
+
+---
+
+## Phase 4 — Wire Architect Skills to the Code Loop
+
+**Goal:** `architect-loop` triggers a real graph iteration instead of orchestrating CLI calls by hand.
+
+| # | Task | Priority | Effort |
+|---|------|----------|--------|
+| 1 | Add `branes session iterate` (or equivalent) that runs one code-level iteration of the unified loop and mutates the persisted `DesignState` | P0 | M |
+| 2 | Rewrite `architect-loop.md` to invoke that command and read back the new `open_issues` / Pareto delta — same bottleneck-hunting UX, real code path underneath | P0 | S |
+| 3 | Point `architect-drill` at `DesignIssue` records; `architect-assess` at the unified multi-level metrics (`architect-workflows.md`) | P1 | M |
+| 4 | Convergence controller: single loop condition (hypervolume Δ < ε for N iters **OR** empty `open_issues` **OR** critic "diminishing returns") replacing the two separate stop conditions | P1 | M |
+
+**Exit criteria:** A user runs `architect-loop` and each pass is a genuine code iteration of the
+unified loop — the critic finds bottlenecks, the optimizer/specialists resolve them against one
+`DesignState`, and the loop halts on the shared convergence condition. The human is *steering*
+the loop, not *being* it.
+
+---
+
+## Critical Path
+
+```
+Phase 1 (unify state) ──→ Phase 2 (agent critic+optimizer) ──→ Phase 4 (wire skills + convergence)
+        └──────────────────→ Phase 3 (specialist agents) ──────┘
+```
+
+Phase 1 gates everything. Phases 2 and 3 can proceed in parallel once the state is unified.
+Phase 4 needs both.
+
+---
+
+## Implementation Seams (from the executable skeleton)
+
+A DRAFT skeleton exists and passes the Black+Ruff gate; the compiled graph drives a full
+failing→converged cycle with a fake MOO tool. It is wired to nothing (import-only). The
+remaining work is filling these named seams:
+
+- `src/embodied_ai_architect/graphs/design_state.py` — unified `DesignState` + `DesignIssue` / `DesignDelta` + lifecycle helpers
+- `src/embodied_ai_architect/graphs/loop_agents.py` — `Critic` / `Optimizer` agents + node wrappers + router
+- `src/embodied_ai_architect/graphs/loop_convergence_graph.py` — graph assembly + `MooTool` engine adapter + endpoints
+
+| # | Seam | Location | Phase | Status |
+|---|------|----------|-------|--------|
+| S1 | **Schema audit** — every field any node writes must be declared in `DesignState`, or LangGraph silently drops it at runtime (found `final_report` / `research_citations` / `pending_specialist_tasks` this way). Exhaustively reconcile all node writes against the schema before deleting the old schemas. | `design_state.py` | 1 | ☐ |
+| S2 | **State migration + compat shims** — subsume `SoCDesignState` + `OptimizationLoopState`; keep existing `moo_results` / snapshot / API consumers (CLAUDE.md field table) resolving; run the full test suite as the gate. | `design_state.py`, `soc_state.py`, `optimization_loop.py` | 1 | ☐ |
+| S3 | **`DesignDelta.change` discriminated union** — replace the free-form `dict` payload with a per-`DeltaKind` typed model so edits validate at the boundary. | `design_state.py` | 1 | ☐ |
+| S4 | **LLM critic path** — `Critic._review_with_llm` is a documented `NotImplementedError`. Assemble prompt from PPA + Pareto + `open_issues` + retrieved research (reuse `optimization_loop._reason_with_llm` shape), require JSON, parse into `CriticVerdict`. | `loop_agents.py` | 2 | ☐ |
+| S5 | **Research-grounded deltas** — `_default_delta_for` presets are crude per-metric guesses (power→int8, latency→more MAC rows). The LLM path should propose targeted deltas grounded in the research library. | `loop_agents.py` | 2 | ☐ |
+| S6 | **Real `_merge_pareto`** — the accumulation stub in the MOO tool must reuse `moo.specialist._merge_pareto_frontiers` (monotonic; regression test for frontier monotonicity). | `loop_convergence_graph.py` | 2 | ☐ |
+| S7 | **Real `evaluate_node`** — replace the deterministic constraint check with the actual `ppa_assessor` so verdicts match the rest of the pipeline. | `loop_convergence_graph.py` | 2 | ☐ |
+| S8 | **Specialist retask execution** — `SPECIALIST_RETASK` deltas enqueue `pending_specialist_tasks`; the dispatcher must consume them and re-run the named specialist (issue #35-style re-validation after a config change). | `loop_agents.py`, `dispatcher.py` | 3 | ☐ |
+| S9 | **Specialist agents + estimator tools** — wrap `physical_estimators.py` / `specialists.py` as verdict-first tools; promote the 2–3 judgment-bearing specialists to agents. | `specialists.py`, `physical_estimators.py` | 3 | ☐ |
+| S10 | **Decompose/formulate front door** — `seed_node` stands in for the real mission → constraints → joint design space entry (reuse `MissionDecomposer` + `create_joint_design_space`). | `loop_convergence_graph.py`, `research/decomposer.py` | 4 | ☐ |
+| S11 | **Wire architect skills to the loop** — add `branes session iterate` running one code-level loop iteration; rewrite `architect-loop.md` to invoke it instead of orchestrating CLI calls. | CLI, `.claude/commands/architect-loop.md` | 4 | ☐ |
+| S12 | **Convergence tuning** — `has_converged` uses a fixed hypervolume epsilon; calibrate against real runs and add the critic's "diminishing returns" judgment as a third signal. | `design_state.py`, `loop_agents.py` | 4 | ☐ |
+
+---
+
+## Success Criteria (release-level)
+
+| Metric | Target |
+|--------|--------|
+| One `DesignState` schema; the second schema deleted | Phase 1 |
+| Critic emits structured `DesignDelta` / `DesignIssue`, not free text | Phase 2 |
+| Optimizer applies critic deltas as concrete design-space edits | Phase 2 |
+| ≥2 specialists reason over shared state via estimator tools | Phase 3 |
+| `architect-loop` runs a real code iteration, not manual CLI orchestration | Phase 4 |
+| Single convergence condition governs the unified loop | Phase 4 |
+| End-to-end: NL mission → unified loop → design meeting all constraints, with an auditable trail of which issues each iteration closed | Release |
+
+---
+
+## Non-Goals
+
+- New objectives or design-space dimensions (Phases 1–3 of `agentic-optimization-loop.md`
+  already delivered these — this release restructures the loop, it does not widen it).
+- Co-simulation validation (that is roadmap-v2 R0.9, and it consumes this release's output).
+- Agent-ifying purely numeric specialists with no judgment content.
+- Replacing the MOO engine — it becomes a tool, unchanged internally.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| State unification breaks the many existing `moo_results` / snapshot / API consumers (CLAUDE.md field table) | Phase 1 compat shims + run the existing test suite as the gate before deleting the old schema |
+| LLM-in-the-loop cost/latency per iteration | Deterministic fallback paths (Phase 2/4); cap agent turns per iteration; reuse token cost tracking |
+| Over-agent-ifying deterministic estimators adds nondeterminism without value | Phase 3 explicitly keeps numeric specialists as tools; only judgment-bearing nodes become agents |
+| Two-loop merge changes convergence behavior / regresses Pareto monotonicity | Keep `_merge_pareto_frontiers` monotonic-accumulation invariant; add a frontier-monotonicity regression test |

--- a/docs/plans/roadmap-v2.md
+++ b/docs/plans/roadmap-v2.md
@@ -133,10 +133,12 @@ Feb 2026        Mar–Apr 2026     May–Jul 2026      Aug–Nov 2026       Dec 
 | Optimization loop diverges (oscillates between strategies) | Medium | High | Monotonicity check: reject iterations that regress on primary metric |
 | Experience cache grows unbounded | Low | Medium | TTL + LRU eviction; archive old designs |
 | Surrogate model inaccuracy misleads search | Medium | Medium | Validation against full PPA assessor every N iterations |
+| Ships as two disjoint loops (population MOO + single-design dispatcher) with two state schemas; specialists stay deterministic, critic feedback stays coarse | High | High | Follow-on **Loop Convergence** milestone (`roadmap-loop-convergence.md`) unifies on one `DesignState`, agent-ifies critic/optimizer, wires architect skills to a real code iteration |
 
 ### Dependencies
 
 - Requires Release 0.7 (CLI must work for testing the loop end-to-end)
+- Followed by the **Loop Convergence** milestone (`roadmap-loop-convergence.md`) — slots between 0.8 and 0.9; unifies the two loops into one multi-agent loop before co-simulation consumes the design state
 
 ---
 
@@ -177,6 +179,7 @@ Feb 2026        Mar–Apr 2026     May–Jul 2026      Aug–Nov 2026       Dec 
 
 - Requires Release 0.7 (remote backends for running sims on cluster)
 - Can run in parallel with Release 0.8 (independent engineering track)
+- Benefits from the **Loop Convergence** milestone (`roadmap-loop-convergence.md`): co-sim validates against a single unified `DesignState`, so co-sim instrumentation is simpler if Loop Convergence lands first (not a hard blocker)
 
 ---
 
@@ -318,6 +321,14 @@ Feb 2026        Mar–Apr 2026     May–Jul 2026      Aug–Nov 2026       Dec 
            │ • Experience  │   │ • Calibration    │
            │ • Governance  │   │ • Energy tracing │
            └────────┬──────┘   └───┬──────────────┘
+                    │              ▲
+           ┌────────▼───────────┐  ┆ (benefits: unified
+           │ Loop Convergence   │┄┄┘  DesignState)
+           │ • Unify DesignState│
+           │ • Agent critic/opt │
+           │ • Specialist agents│
+           │ • Skills→code loop │
+           └────────┬───────────┘
                     │              │
                     └──────┬───────┘
                            │
@@ -353,17 +364,17 @@ Feb 2026        Mar–Apr 2026     May–Jul 2026      Aug–Nov 2026       Dec 
 
 The longest dependency chain determines the minimum timeline:
 
-1. **0.7 → 0.8 → 1.0** (10 months) — The optimization loop is the core differentiator. It must work before we can sell.
-2. **0.9** runs in parallel with 0.8 if there's a second engineer on co-simulation.
+1. **0.7 → 0.8 → Loop Convergence → 1.0** (~12 months) — The optimization loop is the core differentiator, and Loop Convergence (`roadmap-loop-convergence.md`) is what turns it from LLM-supervised search into a unified multi-agent design loop. It sits on the critical path to a credible customer release.
+2. **0.9** runs in parallel with 0.8 + Loop Convergence if there's a second engineer on co-simulation; it consumes the unified `DesignState` so it benefits from Loop Convergence landing first (soft, not hard, dependency).
 3. **1.1 → 1.2** is sequential — enterprise features enable the customer relationships needed for sim-to-real hardware access.
 
 ### Staffing Implications
 
 | Engineers | Timeline to 1.0 | Notes |
 |-----------|-----------------|-------|
-| 1 | 14 months | Sequential: 0.7 → 0.8 → 0.9 → 1.0 |
-| 2 | 12 months | Parallel: 0.8 ‖ 0.9, then converge at 1.0 |
-| 3 | 10 months | Also parallelize RISC-V/FPGA targets |
+| 1 | 16 months | Sequential: 0.7 → 0.8 → Loop Convergence → 0.9 → 1.0 |
+| 2 | 13 months | Parallel: (0.8 → Loop Convergence) ‖ 0.9, then converge at 1.0 |
+| 3 | 11 months | Also parallelize RISC-V/FPGA targets |
 
 ---
 

--- a/src/embodied_ai_architect/graphs/design_state.py
+++ b/src/embodied_ai_architect/graphs/design_state.py
@@ -287,9 +287,9 @@ class DesignState(TypedDict, total=False):
     pending_specialist_tasks: list[dict]  # SPECIALIST_RETASK deltas the dispatcher picks up
 
     # --- Reasoning output (OptimizationLoopState) ---
+    # (research_citations is declared once, above, in the decomposition section)
     analysis: str
     recommendation: dict
-    research_citations: list[str]
     final_report: str
 
     # --- Loop control (merged) ---
@@ -297,6 +297,7 @@ class DesignState(TypedDict, total=False):
     max_iterations: int
     converged: bool
     should_iterate: bool
+    llm_available: bool  # gates the reasoning agents' LLM path (read by critic_node)
 
     # --- History / governance / cost (SoCDesignState) ---
     history: list[dict]  # DesignDecision entries

--- a/src/embodied_ai_architect/graphs/design_state.py
+++ b/src/embodied_ai_architect/graphs/design_state.py
@@ -1,0 +1,375 @@
+"""Unified DesignState schema — DRAFT sketch for the Loop Convergence milestone.
+
+See `docs/plans/roadmap-loop-convergence.md`.
+
+This module is a **proposal**, not yet wired into any graph. It sketches the single
+state schema that subsumes the two existing, disjoint schemas:
+
+    graphs/soc_state.py:SoCDesignState        (single-design dispatcher loop)
+    graphs/optimization_loop.py:OptimizationLoopState  (population / Pareto MOO loop)
+
+...plus the two new structured types that become the *shared currency* between a
+reasoning Critic and a reasoning Optimizer, replacing today's coarse free-text
+"iterate" feedback:
+
+    DesignIssue  — a typed bottleneck record (critic/specialists -> backlog)
+    DesignDelta  — a concrete, applyable edit (critic -> optimizer)
+
+Field convention follows the existing code: the TypedDict stores plain serialized
+dicts/lists (not Pydantic instances) so LangGraph can checkpoint it, while the
+Pydantic models below define/validate those payloads before they are dumped in.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Optional
+from typing_extensions import TypedDict
+import uuid
+
+from pydantic import BaseModel, Field
+
+# Reuse the existing, already-shipped models so the subsumption is real, not a copy.
+from embodied_ai_architect.graphs.soc_state import (
+    DesignConstraints,  # noqa: F401  (re-exported for callers)
+    DesignDecision,  # noqa: F401
+    DesignStatus,  # noqa: F401
+    PPAMetrics,  # noqa: F401
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared enums — vocabularies the critic, specialists, and optimizer agree on
+# ---------------------------------------------------------------------------
+
+
+class MetricAxis(str, Enum):
+    """The metric a DesignIssue is about. Mirrors the architect-workflows.md axes."""
+
+    POWER = "power"
+    LATENCY = "latency"
+    THROUGHPUT = "throughput"
+    AREA = "area"
+    COST = "cost"
+    THERMAL = "thermal"
+    ACCURACY = "accuracy"
+    CAPABILITY_PER_WATT = "capability_per_watt"
+    UTILIZATION = "utilization"
+    BANDWIDTH = "bandwidth"
+    MEMORY = "memory"
+    WEIGHT = "weight"
+    VOLUME = "volume"
+    RELIABILITY = "reliability"
+
+
+class AbstractionLevel(str, Enum):
+    """Where in the composition hierarchy the issue lives (architect-workflows.md)."""
+
+    SYSTEM = "system"
+    SUBSYSTEM = "subsystem"
+    OPERATOR = "operator"
+    KERNEL = "kernel"
+    HARDWARE = "hardware"
+    PHYSICAL = "physical"
+
+
+class Severity(str, Enum):
+    CRITICAL = "critical"  # constraint violated
+    HIGH = "high"  # dominant bottleneck, little headroom
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class IssueStatus(str, Enum):
+    OPEN = "open"
+    IN_PROGRESS = "in_progress"  # a delta targeting it has been proposed
+    RESOLVED = "resolved"
+    WONTFIX = "wontfix"  # accepted trade-off
+
+
+class DeltaKind(str, Enum):
+    """The concrete action an Optimizer agent can apply to close issues."""
+
+    DESIGN_SPACE_EDIT = "design_space_edit"  # change a variable's value/category
+    VARIABLE_BOUND_CHANGE = "variable_bound_change"  # widen/narrow search bounds
+    ADD_VARIABLE = "add_variable"  # bring a new degree of freedom into the space
+    REMOVE_VARIABLE = "remove_variable"  # freeze a variable
+    CONSTRAINT_RELAXATION = "constraint_relaxation"  # negotiate a constraint
+    SPECIALIST_RETASK = "specialist_retask"  # re-run/redirect a specialist agent
+
+
+# ---------------------------------------------------------------------------
+# DesignIssue — the shared backlog currency
+# ---------------------------------------------------------------------------
+
+
+class DesignIssue(BaseModel):
+    """A structured bottleneck record.
+
+    Replaces the free-text strings in `PPAMetrics.bottlenecks`. Emitted by the
+    critic and by specialist agents; consumed by the optimizer and the
+    architect-drill / architect-assess skills.
+    """
+
+    id: str = Field(default_factory=lambda: f"issue-{uuid.uuid4().hex[:8]}")
+    metric: MetricAxis = Field(..., description="Which metric this issue is about")
+    level: AbstractionLevel = Field(..., description="Composition level of the bottleneck")
+    component: Optional[str] = Field(
+        default=None, description="Operator/block/kernel name, e.g. 'yolo_detector' or 'FFT'"
+    )
+    severity: Severity = Severity.MEDIUM
+
+    summary: str = Field(..., description="One-line statement of the bottleneck")
+    observed_value: Optional[float] = None
+    target_value: Optional[float] = Field(
+        default=None, description="Constraint or budget this metric must meet"
+    )
+    contribution_pct: Optional[float] = Field(
+        default=None, description="Share of the system total this component drives (0-100)"
+    )
+
+    status: IssueStatus = IssueStatus.OPEN
+    raised_by: str = Field(..., description="Agent that raised it, e.g. 'critic'")
+    resolved_by: Optional[str] = None
+    iteration_raised: int = 0
+    iteration_resolved: Optional[int] = None
+
+    # Links to the deltas proposed to close this issue.
+    delta_ids: list[str] = Field(default_factory=list)
+
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def is_open(self) -> bool:
+        return self.status in (IssueStatus.OPEN, IssueStatus.IN_PROGRESS)
+
+
+# ---------------------------------------------------------------------------
+# DesignDelta — the concrete, applyable edit (critic -> optimizer)
+# ---------------------------------------------------------------------------
+
+
+class DesignDelta(BaseModel):
+    """A single, applyable change to the design or the search.
+
+    This is what the Critic emits *instead of* a free-text "iterate" verdict, and
+    what the Optimizer agent consumes to make a concrete edit before re-running the
+    MOO engine (now a tool, not the loop body).
+    """
+
+    id: str = Field(default_factory=lambda: f"delta-{uuid.uuid4().hex[:8]}")
+    kind: DeltaKind
+
+    target: str = Field(
+        ...,
+        description="What is changed: a design-space variable name, a constraint field, "
+        "or a specialist/task id (dotted paths allowed, e.g. 'hardware.array_rows').",
+    )
+    # Free-form because the payload shape depends on `kind`:
+    #   DESIGN_SPACE_EDIT      -> {"value": <new value>}
+    #   VARIABLE_BOUND_CHANGE  -> {"bounds": [lo, hi]} or {"categories": [...]}
+    #   ADD_VARIABLE           -> {"variable": <DesignVariable spec>}
+    #   CONSTRAINT_RELAXATION  -> {"from": <old>, "to": <new>}
+    #   SPECIALIST_RETASK      -> {"specialist": "bandwidth_validator", "reason": "..."}
+    change: dict[str, Any] = Field(default_factory=dict)
+
+    rationale: str = Field(..., description="Why this edit should help")
+    addresses_issue_ids: list[str] = Field(
+        default_factory=list, description="Issues this delta is meant to close"
+    )
+    proposed_by: str = Field(default="critic")
+
+    applied: bool = False
+    applied_at_iteration: Optional[int] = None
+
+
+# ---------------------------------------------------------------------------
+# DesignState — the single TypedDict both loops flow through
+# ---------------------------------------------------------------------------
+
+
+class DesignState(TypedDict, total=False):
+    """Unified state schema. Superset of SoCDesignState + OptimizationLoopState.
+
+    total=False: every field is optional; nodes populate what they own. Values are
+    plain serialized dicts/lists (checkpoint-friendly), validated by the Pydantic
+    models above before insertion.
+    """
+
+    # --- Identity / lifecycle (SoCDesignState) ---
+    session_id: str
+    goal: str
+    status: str  # DesignStatus value
+    created_at: str
+    updated_at: str
+
+    # --- Mission input & decomposition (OptimizationLoopState) ---
+    mission_description: str
+    mission_plan: dict
+    platform: str
+    mission_type: str
+    sub_capabilities: list[dict]
+    research_docs_used: list[str]
+    research_citations: list[str]
+
+    # --- Requirements & context (SoCDesignState) ---
+    constraints: dict  # DesignConstraints serialized
+    platform_context: dict
+    task_graph: dict  # TaskGraph serialized
+
+    # --- Design point & joint design space (merged) ---
+    design_space_config: dict  # joint_design_space serialized
+    num_variables: int
+    current_design_point: dict  # the single point under evaluation (dispatcher loop)
+
+    # --- Architecture artifacts (SoCDesignState) ---
+    workload_profile: dict
+    codebase_metadata: dict
+    hardware_candidates: list[dict]
+    selected_architecture: dict
+    ip_blocks: list[dict]
+    memory_map: dict
+    interconnect: dict
+    rtl_modules: dict  # name -> Verilog
+
+    # --- KPU / RTL inner loop (SoCDesignState) ---
+    kpu_config: dict
+    kpu_config_overrides: dict
+    floorplan_estimate: dict
+    bandwidth_match: dict
+    kpu_optimization_history: list[dict]
+    rtl_synthesis_results: dict
+    rtl_optimization_history: list[dict]
+
+    # --- PPA & multi-objective results (merged; both loops write here) ---
+    ppa_metrics: dict  # PPAMetrics serialized
+    baseline_metrics: dict
+    pareto_points: list[dict]  # accumulated non-dominated points
+    pareto_frontier_history: list[dict]
+    moo_results: dict
+    hypervolume_history: list[float]
+    knee_point: dict
+    sensitivity: dict
+    atlas: dict
+    convergence_history: list[dict]
+
+    # --- NEW: shared multi-agent currency (the Loop Convergence delta) ---
+    open_issues: list[dict]  # DesignIssue serialized — the bottleneck backlog
+    pending_deltas: list[dict]  # DesignDelta serialized — proposed, not yet applied
+    applied_deltas: list[dict]  # DesignDelta serialized — history of edits
+    pending_specialist_tasks: list[dict]  # SPECIALIST_RETASK deltas the dispatcher picks up
+
+    # --- Reasoning output (OptimizationLoopState) ---
+    analysis: str
+    recommendation: dict
+    research_citations: list[str]
+    final_report: str
+
+    # --- Loop control (merged) ---
+    iteration: int
+    max_iterations: int
+    converged: bool
+    should_iterate: bool
+
+    # --- History / governance / cost (SoCDesignState) ---
+    history: list[dict]  # DesignDecision entries
+    design_rationale: list[str]
+    working_memory: dict
+    optimization_history: list[dict]
+    governance: dict
+    audit_log: list[dict]
+    cost_tracking: dict
+    evaluation_scorecard: dict
+
+    # --- Human-in-the-loop review/steering (SoCDesignState) ---
+    review_snapshot: dict
+    optimization_review_snapshot: dict
+    optimization_steering: dict
+
+    # --- Error tracking (OptimizationLoopState) ---
+    errors: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Minimal helpers (sketch — the real graph nodes will use these)
+# ---------------------------------------------------------------------------
+
+
+def create_initial_design_state(
+    goal: str,
+    *,
+    constraints: Optional[DesignConstraints] = None,
+    mission_description: Optional[str] = None,
+    session_id: Optional[str] = None,
+) -> DesignState:
+    """Seed a fresh unified state. Convert-and-adapt entry point for both loops."""
+    now = datetime.now().isoformat()
+    state: DesignState = {
+        "session_id": session_id or f"design-{uuid.uuid4().hex[:8]}",
+        "goal": goal,
+        "status": DesignStatus.PLANNING.value,
+        "created_at": now,
+        "updated_at": now,
+        "constraints": (constraints or DesignConstraints()).model_dump(),
+        "open_issues": [],
+        "pending_deltas": [],
+        "applied_deltas": [],
+        "iteration": 0,
+        "converged": False,
+        "errors": [],
+    }
+    if mission_description:
+        state["mission_description"] = mission_description
+    return state
+
+
+def add_issue(state: DesignState, issue: DesignIssue) -> DesignState:
+    """Append a validated issue to the backlog."""
+    state.setdefault("open_issues", []).append(issue.model_dump(mode="json"))
+    return state
+
+
+def add_delta(state: DesignState, delta: DesignDelta) -> DesignState:
+    """Record a proposed edit and mark the issues it targets as in-progress."""
+    state.setdefault("pending_deltas", []).append(delta.model_dump(mode="json"))
+    targeted = set(delta.addresses_issue_ids)
+    for raw in state.get("open_issues", []):
+        if raw.get("id") in targeted and raw.get("status") == IssueStatus.OPEN.value:
+            raw["status"] = IssueStatus.IN_PROGRESS.value
+            raw.setdefault("delta_ids", []).append(delta.id)
+    return state
+
+
+def resolve_issue(state: DesignState, issue_id: str, *, by: str, iteration: int) -> DesignState:
+    """Mark an issue resolved once its delta lands and re-evaluation confirms it."""
+    for raw in state.get("open_issues", []):
+        if raw.get("id") == issue_id:
+            raw["status"] = IssueStatus.RESOLVED.value
+            raw["resolved_by"] = by
+            raw["iteration_resolved"] = iteration
+    return state
+
+
+def open_issues(state: DesignState) -> list[DesignIssue]:
+    """Rehydrate the still-open issues, most severe first."""
+    order = {
+        s: i
+        for i, s in enumerate([Severity.CRITICAL, Severity.HIGH, Severity.MEDIUM, Severity.LOW])
+    }
+    issues = [DesignIssue(**raw) for raw in state.get("open_issues", [])]
+    return sorted((i for i in issues if i.is_open), key=lambda i: order[i.severity])
+
+
+def has_converged(state: DesignState, *, hypervolume_epsilon: float = 1e-3) -> bool:
+    """Unified stop condition (replaces the two separate ones).
+
+    Converged when EITHER the issue backlog is empty OR the Pareto hypervolume has
+    stopped improving — whichever the loop reaches first.
+    """
+    if not open_issues(state):
+        return True
+    hv = state.get("hypervolume_history", [])
+    if len(hv) >= 2 and abs(hv[-1] - hv[-2]) < hypervolume_epsilon:
+        return True
+    return False

--- a/src/embodied_ai_architect/graphs/design_state.py
+++ b/src/embodied_ai_architect/graphs/design_state.py
@@ -31,12 +31,38 @@ import uuid
 from pydantic import BaseModel, Field
 
 # Reuse the existing, already-shipped models so the subsumption is real, not a copy.
+# These are re-exported (see __all__) so callers can import them from this module.
 from embodied_ai_architect.graphs.soc_state import (
-    DesignConstraints,  # noqa: F401  (re-exported for callers)
-    DesignDecision,  # noqa: F401
-    DesignStatus,  # noqa: F401
-    PPAMetrics,  # noqa: F401
+    DesignConstraints,
+    DesignDecision,
+    DesignStatus,
+    PPAMetrics,
 )
+
+__all__ = [
+    # Re-exported from soc_state
+    "DesignConstraints",
+    "DesignDecision",
+    "DesignStatus",
+    "PPAMetrics",
+    # Enums
+    "MetricAxis",
+    "AbstractionLevel",
+    "Severity",
+    "IssueStatus",
+    "DeltaKind",
+    # Models
+    "DesignIssue",
+    "DesignDelta",
+    "DesignState",
+    # Lifecycle helpers
+    "create_initial_design_state",
+    "add_issue",
+    "add_delta",
+    "resolve_issue",
+    "open_issues",
+    "has_converged",
+]
 
 
 # ---------------------------------------------------------------------------

--- a/src/embodied_ai_architect/graphs/experience.py
+++ b/src/embodied_ai_architect/graphs/experience.py
@@ -89,7 +89,8 @@ class ExperienceCache:
         self._create_table()
 
     def _create_table(self) -> None:
-        self._conn.execute("""
+        self._conn.execute(
+            """
             CREATE TABLE IF NOT EXISTS episodes (
                 episode_id TEXT PRIMARY KEY,
                 timestamp TEXT NOT NULL,
@@ -100,13 +101,18 @@ class ExperienceCache:
                 iterations_used INTEGER NOT NULL,
                 data TEXT NOT NULL
             )
-        """)
-        self._conn.execute("""
+        """
+        )
+        self._conn.execute(
+            """
             CREATE INDEX IF NOT EXISTS idx_use_case ON episodes(use_case)
-        """)
-        self._conn.execute("""
+        """
+        )
+        self._conn.execute(
+            """
             CREATE INDEX IF NOT EXISTS idx_fingerprint ON episodes(fingerprint)
-        """)
+        """
+        )
         self._conn.commit()
 
     def save(self, episode: DesignEpisode) -> str:

--- a/src/embodied_ai_architect/graphs/loop_agents.py
+++ b/src/embodied_ai_architect/graphs/loop_agents.py
@@ -87,7 +87,7 @@ class ReasoningAgent(ABC):
         self.llm_available = llm_available
         self._llm_client = llm_client  # inject for tests; else lazily constructed
 
-    def _client(self):
+    def _client(self) -> Any:
         if self._llm_client is not None:
             return self._llm_client
         from embodied_ai_architect.llm.client import LLMClient  # lazy: optional dep
@@ -215,7 +215,11 @@ class Optimizer(ReasoningAgent):
         if delta.kind == DeltaKind.DESIGN_SPACE_EDIT:
             _set_path(space, delta.target, delta.change.get("value"))
         elif delta.kind == DeltaKind.VARIABLE_BOUND_CHANGE:
-            _set_path(space, f"{delta.target}.bounds", delta.change.get("bounds"))
+            # Continuous vars carry {"bounds": [lo, hi]}; categorical vars {"categories": [...]}.
+            if "categories" in delta.change:
+                _set_path(space, f"{delta.target}.categories", delta.change.get("categories"))
+            else:
+                _set_path(space, f"{delta.target}.bounds", delta.change.get("bounds"))
         elif delta.kind == DeltaKind.ADD_VARIABLE:
             space.setdefault("variables", {})[delta.target] = delta.change.get("variable")
         elif delta.kind == DeltaKind.REMOVE_VARIABLE:
@@ -262,20 +266,39 @@ def critic_node(state: DesignState) -> dict:
 
 
 def optimizer_node(state: DesignState, *, moo_tool: Optional[MooTool] = None) -> dict:
-    """Node: apply the pending deltas and re-run MOO as a tool."""
+    """Node: apply the pending deltas and re-run MOO as a tool.
+
+    Returns every field the deltas or the MOO tool touched. LangGraph propagates
+    state purely through the return value — in-place mutation of the input `state`
+    does not reliably reach the merged graph state — so all MOO-tool outputs
+    (knee_point, sensitivity, atlas, moo_results, pareto_frontier_history) are
+    re-emitted here, not just the two the loop happens to read next.
+    """
     optimizer = Optimizer(moo_tool=moo_tool)
     pending = [DesignDelta(**d) for d in state.get("pending_deltas", []) if not d.get("applied")]
     optimizer.optimize(state, pending)
-    return {
+    updates: dict = {
         "design_space_config": state.get("design_space_config", {}),
         "constraints": state.get("constraints", {}),
+        "pending_specialist_tasks": state.get("pending_specialist_tasks", []),
         "applied_deltas": state.get("applied_deltas", []),
         "open_issues": state.get("open_issues", []),
         "pending_deltas": [],  # drained
-        "pareto_points": state.get("pareto_points", []),
-        "hypervolume_history": state.get("hypervolume_history", []),
         "iteration": int(state.get("iteration", 0)) + 1,
     }
+    # Re-emit whatever the MOO tool produced so it lands in the merged state.
+    for key in (
+        "pareto_points",
+        "pareto_frontier_history",
+        "hypervolume_history",
+        "knee_point",
+        "sensitivity",
+        "atlas",
+        "moo_results",
+    ):
+        if key in state:
+            updates[key] = state[key]
+    return updates
 
 
 def route_after_critic(state: DesignState) -> str:

--- a/src/embodied_ai_architect/graphs/loop_agents.py
+++ b/src/embodied_ai_architect/graphs/loop_agents.py
@@ -1,0 +1,335 @@
+"""Critic and Optimizer agent interfaces — DRAFT sketch for the Loop Convergence milestone.
+
+See `docs/plans/roadmap-loop-convergence.md` (Phase 2) and `graphs/design_state.py`.
+
+This module is a **proposal**, not yet wired into any graph. It sketches the two
+reasoning agents that replace today's shallow feedback:
+
+    Critic     — reviews the current DesignState, files structured DesignIssues, and
+                 emits concrete DesignDeltas (instead of a free-text "iterate" verdict).
+                 Promotes `optimization_loop.py:reason_node`.
+
+    Optimizer  — consumes DesignDeltas, applies them as concrete edits to the design
+                 space / constraints / design point, then re-runs the MOO engine *as a
+                 tool* (not as the loop body). Promotes `optimizer.py:design_optimizer`.
+
+Both follow the established house pattern: an LLM path with a deterministic heuristic
+fallback (mirrors `reason_node` → `_reason_with_llm` / `_reason_heuristic`), and both
+expose LangGraph node wrappers `critic_node` / `optimizer_node` returning dict updates.
+
+The MOO engine is injected as a *tool* callable (`MooTool`) so the optimizer depends on
+a boundary, not on the engine internals — the key structural move of this milestone.
+"""
+
+from __future__ import annotations
+
+from abc import ABC
+from typing import Any, Callable, Optional
+
+from pydantic import BaseModel, Field
+
+from embodied_ai_architect.graphs.design_state import (
+    AbstractionLevel,
+    DesignDelta,
+    DesignIssue,
+    DesignState,
+    DeltaKind,
+    IssueStatus,
+    MetricAxis,
+    Severity,
+    add_delta,
+    add_issue,
+    has_converged,
+)
+
+# A MooTool takes the current state and returns the state fields the MOO run produces
+# (pareto_points, pareto_frontier_history, moo_results, hypervolume_history, sensitivity,
+# atlas, ...). This is the boundary that turns the MOO engine from "the loop" into "a tool".
+MooTool = Callable[[DesignState], dict]
+
+
+# ---------------------------------------------------------------------------
+# Critic output
+# ---------------------------------------------------------------------------
+
+
+class CriticVerdict(BaseModel):
+    """What a Critic returns from a single review pass."""
+
+    issues: list[DesignIssue] = Field(
+        default_factory=list, description="New or updated bottlenecks for the backlog"
+    )
+    deltas: list[DesignDelta] = Field(
+        default_factory=list, description="Concrete edits proposed to close the issues"
+    )
+    converged: bool = Field(
+        default=False, description="Critic judges diminishing returns — stop the loop"
+    )
+    analysis: str = Field(default="", description="Human-readable rationale")
+    research_citations: list[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Shared base — LLM path with deterministic fallback (house pattern)
+# ---------------------------------------------------------------------------
+
+
+class ReasoningAgent(ABC):
+    """Base for agents that reason with Claude but degrade to a heuristic offline.
+
+    Mirrors `reason_node`'s try-LLM-then-heuristic shape so behaviour (and testability
+    without an API key) is identical across the loop's reasoning nodes.
+    """
+
+    name: str = "reasoning_agent"
+
+    def __init__(self, *, llm_available: bool = False, llm_client: Optional[Any] = None):
+        self.llm_available = llm_available
+        self._llm_client = llm_client  # inject for tests; else lazily constructed
+
+    def _client(self):
+        if self._llm_client is not None:
+            return self._llm_client
+        from embodied_ai_architect.llm.client import LLMClient  # lazy: optional dep
+
+        self._llm_client = LLMClient()
+        return self._llm_client
+
+
+# ---------------------------------------------------------------------------
+# Critic
+# ---------------------------------------------------------------------------
+
+
+class Critic(ReasoningAgent):
+    """Reviews a DesignState and produces a structured verdict.
+
+    Replaces free-text `PPAMetrics.bottlenecks` / `reason_node`'s "iterate" string with
+    typed `DesignIssue`s and applyable `DesignDelta`s.
+    """
+
+    name = "critic"
+
+    def review(self, state: DesignState) -> CriticVerdict:
+        """Single review pass. Never raises — falls back to heuristic on any LLM error."""
+        if self.llm_available:
+            try:
+                return self._review_with_llm(state)
+            except Exception:  # pragma: no cover - parity with reason_node fallback
+                pass
+        return self._review_heuristic(state)
+
+    # -- LLM path -----------------------------------------------------------
+
+    def _review_with_llm(self, state: DesignState) -> CriticVerdict:
+        """Claude ranks bottlenecks with research context and proposes deltas.
+
+        Implementation sketch: build a prompt from ppa_metrics + Pareto front + the
+        current open_issues backlog + retrieved research (as `_reason_with_llm` does),
+        require JSON out, and parse into CriticVerdict. Research retrieval and prompt
+        assembly are elided here — see optimization_loop._reason_with_llm for the shape.
+        """
+        raise NotImplementedError("LLM critic path — assemble prompt + parse JSON verdict")
+
+    # -- Heuristic path -----------------------------------------------------
+
+    def _review_heuristic(self, state: DesignState) -> CriticVerdict:
+        """Deterministic critic: derive issues from failing PPA verdicts.
+
+        Enough to run the loop end-to-end without an API key, and to seed regression
+        tests. The LLM path enriches this with rationale, cross-metric reasoning, and
+        research-grounded deltas.
+        """
+        ppa = state.get("ppa_metrics", {})
+        verdicts: dict[str, str] = ppa.get("verdicts", {})
+        iteration = int(state.get("iteration", 0))
+
+        issues: list[DesignIssue] = []
+        deltas: list[DesignDelta] = []
+
+        for metric_name, verdict in verdicts.items():
+            if verdict != "FAIL":
+                continue
+            metric = _to_metric_axis(metric_name)
+            issue = DesignIssue(
+                metric=metric,
+                level=AbstractionLevel.SYSTEM,
+                severity=Severity.CRITICAL,
+                summary=f"{metric_name} constraint failing",
+                observed_value=ppa.get(f"{metric_name}"),
+                raised_by=self.name,
+                iteration_raised=iteration,
+            )
+            delta = _default_delta_for(metric, issue)
+            issue.delta_ids.append(delta.id)
+            issues.append(issue)
+            deltas.append(delta)
+
+        # Converge when the critic sees nothing failing AND the frontier has stopped moving.
+        converged = not issues and has_converged(state)
+        analysis = (
+            "No failing constraints; frontier stable — recommend."
+            if converged
+            else f"{len(issues)} failing constraint(s); proposed {len(deltas)} edit(s)."
+        )
+        return CriticVerdict(issues=issues, deltas=deltas, converged=converged, analysis=analysis)
+
+
+# ---------------------------------------------------------------------------
+# Optimizer
+# ---------------------------------------------------------------------------
+
+
+class Optimizer(ReasoningAgent):
+    """Applies DesignDeltas as concrete edits, then re-runs the MOO engine as a tool.
+
+    Promotes `optimizer.py:design_optimizer`: instead of picking a coarse strategy from a
+    catalog, it executes the critic's specific edits, records provenance, and can re-task
+    specialists. The MOO run is a tool call, not the loop body.
+    """
+
+    name = "optimizer"
+
+    def __init__(self, *, moo_tool: Optional[MooTool] = None, **kwargs):
+        super().__init__(**kwargs)
+        self.moo_tool = moo_tool
+
+    def optimize(self, state: DesignState, deltas: list[DesignDelta]) -> DesignState:
+        """Apply each delta to `state`, then run the MOO tool over the edited space."""
+        for delta in deltas:
+            self._apply_delta(state, delta)
+        if self.moo_tool is not None:
+            moo_updates = self.moo_tool(state)
+            state.update(moo_updates)  # pareto_points, hypervolume_history, sensitivity, ...
+        return state
+
+    def _apply_delta(self, state: DesignState, delta: DesignDelta) -> None:
+        """Dispatch a single delta to a concrete state mutation.
+
+        Each branch is a real, auditable edit — the antithesis of "re-run MAP-Elites
+        with more effort". Retasking is expressed as a queued specialist request that
+        the dispatcher picks up (issue #35-style re-validation after a config change).
+        """
+        space = state.setdefault("design_space_config", {})
+
+        if delta.kind == DeltaKind.DESIGN_SPACE_EDIT:
+            _set_path(space, delta.target, delta.change.get("value"))
+        elif delta.kind == DeltaKind.VARIABLE_BOUND_CHANGE:
+            _set_path(space, f"{delta.target}.bounds", delta.change.get("bounds"))
+        elif delta.kind == DeltaKind.ADD_VARIABLE:
+            space.setdefault("variables", {})[delta.target] = delta.change.get("variable")
+        elif delta.kind == DeltaKind.REMOVE_VARIABLE:
+            space.get("variables", {}).pop(delta.target, None)
+        elif delta.kind == DeltaKind.CONSTRAINT_RELAXATION:
+            _set_path(state.setdefault("constraints", {}), delta.target, delta.change.get("to"))
+        elif delta.kind == DeltaKind.SPECIALIST_RETASK:
+            state.setdefault("pending_specialist_tasks", []).append(
+                {"specialist": delta.target, **delta.change}
+            )
+
+        delta.applied = True
+        delta.applied_at_iteration = int(state.get("iteration", 0))
+        state.setdefault("applied_deltas", []).append(delta.model_dump(mode="json"))
+        # Mark the issues this delta closed as resolved (re-evaluation confirms next pass).
+        for issue_id in delta.addresses_issue_ids:
+            for raw in state.get("open_issues", []):
+                if raw.get("id") == issue_id:
+                    raw["status"] = IssueStatus.RESOLVED.value
+                    raw["resolved_by"] = self.name
+                    raw["iteration_resolved"] = int(state.get("iteration", 0))
+
+
+# ---------------------------------------------------------------------------
+# LangGraph node wrappers + router (how they plug into the unified loop)
+# ---------------------------------------------------------------------------
+
+
+def critic_node(state: DesignState) -> dict:
+    """Node: run the critic, fold its verdict into the shared backlog."""
+    critic = Critic(llm_available=bool(state.get("llm_available", False)))
+    verdict = critic.review(state)
+    for issue in verdict.issues:
+        add_issue(state, issue)
+    for delta in verdict.deltas:
+        add_delta(state, delta)
+    return {
+        "open_issues": state.get("open_issues", []),
+        "pending_deltas": state.get("pending_deltas", []),
+        "converged": verdict.converged,
+        "analysis": verdict.analysis,
+        "research_citations": verdict.research_citations,
+    }
+
+
+def optimizer_node(state: DesignState, *, moo_tool: Optional[MooTool] = None) -> dict:
+    """Node: apply the pending deltas and re-run MOO as a tool."""
+    optimizer = Optimizer(moo_tool=moo_tool)
+    pending = [DesignDelta(**d) for d in state.get("pending_deltas", []) if not d.get("applied")]
+    optimizer.optimize(state, pending)
+    return {
+        "design_space_config": state.get("design_space_config", {}),
+        "constraints": state.get("constraints", {}),
+        "applied_deltas": state.get("applied_deltas", []),
+        "open_issues": state.get("open_issues", []),
+        "pending_deltas": [],  # drained
+        "pareto_points": state.get("pareto_points", []),
+        "hypervolume_history": state.get("hypervolume_history", []),
+        "iteration": int(state.get("iteration", 0)) + 1,
+    }
+
+
+def route_after_critic(state: DesignState) -> str:
+    """Conditional edge: recommend when converged, else keep optimizing.
+
+    Single decision point that replaces the two loops' separate stop conditions.
+    """
+    if state.get("converged") or has_converged(state):
+        return "recommend"
+    return "optimize"
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_metric_axis(name: str) -> MetricAxis:
+    try:
+        return MetricAxis(name.lower())
+    except ValueError:
+        # Map common PPA verdict keys onto axes; default to POWER as the dominant driver.
+        return {
+            "power_watts": MetricAxis.POWER,
+            "latency_ms": MetricAxis.LATENCY,
+            "area_mm2": MetricAxis.AREA,
+            "cost_usd": MetricAxis.COST,
+            "accuracy_percent": MetricAxis.ACCURACY,
+        }.get(name, MetricAxis.POWER)
+
+
+def _default_delta_for(metric: MetricAxis, issue: DesignIssue) -> DesignDelta:
+    """Heuristic first-guess edit per metric (the LLM path proposes better-targeted ones)."""
+    presets: dict[MetricAxis, dict[str, Any]] = {
+        MetricAxis.POWER: {"target": "quantization_dtype", "change": {"value": "int8"}},
+        MetricAxis.LATENCY: {"target": "hardware.array_rows", "change": {"value": 32}},
+        MetricAxis.AREA: {"target": "hardware.sram_kb", "change": {"value": 256}},
+        MetricAxis.COST: {"target": "hardware.process_nm", "change": {"value": 28}},
+    }
+    preset = presets.get(metric, {"target": "quantization_dtype", "change": {"value": "fp16"}})
+    return DesignDelta(
+        kind=DeltaKind.DESIGN_SPACE_EDIT,
+        target=preset["target"],
+        change=preset["change"],
+        rationale=f"Heuristic edit to relieve {metric.value} bottleneck",
+        addresses_issue_ids=[issue.id],
+        proposed_by="critic",
+    )
+
+
+def _set_path(root: dict, dotted: str, value: Any) -> None:
+    """Set a dotted path inside a nested dict, creating intermediate dicts."""
+    keys = dotted.split(".")
+    node = root
+    for key in keys[:-1]:
+        node = node.setdefault(key, {})
+    node[keys[-1]] = value

--- a/src/embodied_ai_architect/graphs/loop_convergence_graph.py
+++ b/src/embodied_ai_architect/graphs/loop_convergence_graph.py
@@ -1,0 +1,257 @@
+"""Unified loop assembly — DRAFT sketch for the Loop Convergence milestone.
+
+See `docs/plans/roadmap-loop-convergence.md` (Phase 4), `graphs/design_state.py`,
+and `graphs/loop_agents.py`.
+
+This module is a **proposal**, not yet wired into the CLI. It assembles the single
+LangGraph loop over the unified `DesignState`, closing the critic ↔ optimizer cycle
+that today is split across two disjoint graphs:
+
+    seed → critic → (route) ──recommend──► recommend → END
+                       │
+                    optimize → evaluate ──► critic   (loop back)
+
+Compared to `optimization_loop.py:build_optimization_loop`, the differences that
+matter are:
+
+  * one state schema (`DesignState`) instead of `OptimizationLoopState` +
+    `SoCDesignState`;
+  * the MOO engine is a **tool** (`MooTool`) the optimizer calls, injected at build
+    time — the graph does not import the engine;
+  * the loop stop condition is single (`route_after_critic` over the `open_issues`
+    backlog + hypervolume), not two separate ones.
+
+The `make_moo_engine_tool` adapter below wraps the real `OptimizationEngine` exactly
+as `optimize_node` does, but maps its output onto `DesignState` field names.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from embodied_ai_architect.graphs.design_state import DesignState
+from embodied_ai_architect.graphs.loop_agents import (
+    MooTool,
+    critic_node,
+    has_converged,
+    optimizer_node,
+)
+
+
+# ---------------------------------------------------------------------------
+# MOO engine, as a tool (the boundary this milestone introduces)
+# ---------------------------------------------------------------------------
+
+
+def make_moo_engine_tool(*, max_workers: int = 4) -> MooTool:
+    """Build a MooTool that runs the real OptimizationEngine over the joint space.
+
+    Mirrors `optimization_loop.optimize_node`'s engine invocation, but returns the
+    subset of results mapped onto unified `DesignState` field names. The optimizer
+    agent calls this; the graph itself never sees the engine.
+    """
+
+    def _run(state: DesignState) -> dict:
+        from embodied_ai_architect.graphs.moo.joint_design_space import (
+            JointEvaluator,
+            create_joint_design_space,
+        )
+        from embodied_ai_architect.graphs.moo.engine import (
+            OptimizationConfig,
+            OptimizationEngine,
+        )
+        from embodied_ai_architect.graphs.moo.map_elites import MAPElitesConfig
+
+        constraints = state.get("constraints", {})
+        iteration = int(state.get("iteration", 0))
+
+        ds = create_joint_design_space(constraints=constraints)
+        evaluator = JointEvaluator(
+            design_space=ds,
+            base_state={"constraints": constraints},
+            constraint_bounds=ds.constraint_bounds,
+        )
+        # Effort scales with iteration, as in optimize_node.
+        me_config = MAPElitesConfig(
+            n_iterations=15 + iteration * 10,
+            batch_size=32 + iteration * 16,
+            initial_population=128 + iteration * 64,
+        )
+        engine = OptimizationEngine(
+            ds,
+            evaluator,
+            OptimizationConfig(layers="map_elites", map_elites=me_config, max_workers=max_workers),
+        )
+        try:
+            result = engine.run()
+        finally:
+            engine.shutdown()
+
+        hv_history = list(state.get("hypervolume_history", [])) + [result.hypervolume]
+        pareto_points = _merge_pareto(state.get("pareto_points", []), result.pareto_front)
+        frontier_history = list(state.get("pareto_frontier_history", [])) + [result.pareto_front]
+
+        # Map engine output → unified DesignState field names.
+        return {
+            "pareto_points": pareto_points,
+            "pareto_frontier_history": frontier_history,
+            "hypervolume_history": hv_history,
+            "knee_point": result.knee_point,
+            "sensitivity": result.sensitivity,
+            "atlas": result.atlas or {},
+            "moo_results": result.model_dump() if hasattr(result, "model_dump") else {},
+        }
+
+    return _run
+
+
+def _merge_pareto(existing: list[dict], new: list[dict]) -> list[dict]:
+    """Monotonic accumulation stub — the real one reuses moo.specialist._merge_pareto_frontiers."""
+    return (existing or []) + list(new or [])
+
+
+# ---------------------------------------------------------------------------
+# Evaluate node — turn the current best design into PPA verdicts the critic reads
+# ---------------------------------------------------------------------------
+
+
+def evaluate_node(state: DesignState) -> dict:
+    """Score the current knee/best design against constraints → ppa_metrics.verdicts.
+
+    The critic reads `ppa_metrics.verdicts`; this node is what produces them from the
+    MOO output. Deterministic sketch — the real version reuses the ppa_assessor.
+    """
+    point = state.get("knee_point") or _first(state.get("pareto_points", []))
+    constraints = state.get("constraints", {})
+    metrics = (point or {}).get("objectives", point or {})
+
+    verdicts: dict[str, str] = {}
+    checks = {
+        "power_watts": constraints.get("max_power_watts"),
+        "latency_ms": constraints.get("max_latency_ms"),
+        "area_mm2": constraints.get("max_area_mm2"),
+        "cost_usd": constraints.get("max_cost_usd"),
+    }
+    for field, limit in checks.items():
+        value = metrics.get(field)
+        if limit is None or value is None:
+            continue
+        verdicts[field] = "PASS" if float(value) <= float(limit) else "FAIL"
+
+    ppa = dict(state.get("ppa_metrics", {}))
+    ppa.update({k: metrics.get(k) for k in checks if metrics.get(k) is not None})
+    ppa["verdicts"] = verdicts
+    return {"ppa_metrics": ppa}
+
+
+# ---------------------------------------------------------------------------
+# Seed + recommend endpoints
+# ---------------------------------------------------------------------------
+
+
+def seed_node(state: DesignState) -> dict:
+    """Entry: ensure a design space + one initial frontier exist before the first review.
+
+    In the full system this also runs decompose/formulate (mission → constraints →
+    joint design space); here it just guarantees the fields the loop needs.
+    """
+    updates: dict = {"status": "exploring"}
+    if not state.get("design_space_config"):
+        updates["design_space_config"] = {"source": "default_joint_space"}
+    return updates
+
+
+def recommend_node(state: DesignState) -> dict:
+    """Terminal: select the final design and emit a short report."""
+    point = state.get("knee_point") or _first(state.get("pareto_points", []))
+    resolved = sum(1 for i in state.get("open_issues", []) if i.get("status") == "resolved")
+    report = (
+        f"Converged after {state.get('iteration', 0)} iteration(s). "
+        f"Resolved {resolved} issue(s). Selected design: {point}."
+    )
+    return {"status": "complete", "recommendation": point or {}, "final_report": report}
+
+
+# ---------------------------------------------------------------------------
+# Router with an iteration cap
+# ---------------------------------------------------------------------------
+
+
+def make_router(max_iterations: int = 6):
+    """Route critic → optimize|recommend, with a hard iteration cap as a backstop."""
+
+    def _route(state: DesignState) -> str:
+        if state.get("converged") or has_converged(state):
+            return "recommend"
+        if int(state.get("iteration", 0)) >= max_iterations:
+            return "recommend"
+        return "optimize"
+
+    return _route
+
+
+# ---------------------------------------------------------------------------
+# Graph assembly
+# ---------------------------------------------------------------------------
+
+
+def build_loop_convergence_graph(
+    *,
+    moo_tool: Optional[MooTool] = None,
+    max_iterations: int = 6,
+):
+    """Assemble and compile the unified loop.
+
+    Args:
+        moo_tool: the MOO-engine boundary the optimizer calls. Defaults to the real
+            engine adapter; inject a fake in tests.
+        max_iterations: backstop so the loop always terminates.
+
+    Returns:
+        A compiled LangGraph app over `DesignState`.
+    """
+    from functools import partial
+
+    from langgraph.graph import END, StateGraph
+
+    tool = moo_tool if moo_tool is not None else make_moo_engine_tool()
+
+    workflow = StateGraph(DesignState)
+    workflow.add_node("seed", seed_node)
+    workflow.add_node("critic", critic_node)
+    workflow.add_node("optimize", partial(optimizer_node, moo_tool=tool))
+    workflow.add_node("evaluate", evaluate_node)
+    workflow.add_node("recommend", recommend_node)
+
+    workflow.set_entry_point("seed")
+    workflow.add_edge("seed", "critic")
+    workflow.add_conditional_edges(
+        "critic",
+        make_router(max_iterations),
+        {"optimize": "optimize", "recommend": "recommend"},
+    )
+    workflow.add_edge("optimize", "evaluate")
+    workflow.add_edge("evaluate", "critic")  # loop back
+    workflow.add_edge("recommend", END)
+
+    return workflow.compile()
+
+
+# ---------------------------------------------------------------------------
+# Convenience runner
+# ---------------------------------------------------------------------------
+
+
+def run_loop_convergence(
+    state: DesignState,
+    *,
+    moo_tool: Optional[MooTool] = None,
+    max_iterations: int = 6,
+) -> DesignState:
+    """Build the graph and invoke it once over `state`."""
+    app = build_loop_convergence_graph(moo_tool=moo_tool, max_iterations=max_iterations)
+    return app.invoke(state)
+
+
+def _first(seq: list[Any]) -> Optional[Any]:
+    return seq[0] if seq else None

--- a/src/embodied_ai_architect/graphs/loop_convergence_graph.py
+++ b/src/embodied_ai_architect/graphs/loop_convergence_graph.py
@@ -27,14 +27,14 @@ as `optimize_node` does, but maps its output onto `DesignState` field names.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from embodied_ai_architect.graphs.design_state import DesignState
 from embodied_ai_architect.graphs.loop_agents import (
     MooTool,
     critic_node,
-    has_converged,
     optimizer_node,
+    route_after_critic,
 )
 
 
@@ -177,15 +177,18 @@ def recommend_node(state: DesignState) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def make_router(max_iterations: int = 6):
-    """Route critic → optimize|recommend, with a hard iteration cap as a backstop."""
+def make_router(max_iterations: int = 6) -> Callable[[DesignState], str]:
+    """Route critic → optimize|recommend, with a hard iteration cap as a backstop.
+
+    Delegates the convergence decision to the single canonical `route_after_critic`
+    (in `loop_agents`) and only adds the iteration-cap backstop on top, so there is
+    one stop-condition implementation, not two.
+    """
 
     def _route(state: DesignState) -> str:
-        if state.get("converged") or has_converged(state):
-            return "recommend"
         if int(state.get("iteration", 0)) >= max_iterations:
             return "recommend"
-        return "optimize"
+        return route_after_critic(state)
 
     return _route
 
@@ -199,7 +202,7 @@ def build_loop_convergence_graph(
     *,
     moo_tool: Optional[MooTool] = None,
     max_iterations: int = 6,
-):
+) -> Any:  # langgraph CompiledStateGraph (untyped to avoid a hard import at module load)
     """Assemble and compile the unified loop.
 
     Args:

--- a/src/embodied_ai_architect/report_server.py
+++ b/src/embodied_ai_architect/report_server.py
@@ -246,7 +246,8 @@ def start_server(port: int = 8000, host: str = "localhost"):
 
     handler = ReportHandler
     with socketserver.TCPServer((host, port), handler) as httpd:
-        print(f"""
+        print(
+            f"""
 ╔════════════════════════════════════════════════════════════╗
 ║  Embodied AI Architect - Report Server                    ║
 ╚════════════════════════════════════════════════════════════╝
@@ -258,7 +259,8 @@ def start_server(port: int = 8000, host: str = "localhost"):
 
   This server simply serves static files from ./reports/
   It is completely separate from the orchestrator.
-        """)
+        """
+        )
         try:
             httpd.serve_forever()
         except KeyboardInterrupt:


### PR DESCRIPTION
## Summary

Establishes the **Loop Convergence** milestone — unify the two disjoint design loops (population/Pareto MOO in `optimization_loop.py` + single-design dispatcher in `soc_graph.py`) into one multi-agent loop over a shared `DesignState`, with a reasoning Critic and Optimizer exchanging structured `DesignIssue`/`DesignDelta` records.

This PR is **planning + a DRAFT, import-only skeleton** (wired to nothing). It does not change any runtime behavior. Implementation is tracked as sub-issues of the epic.

**Docs**
- `docs/plans/roadmap-loop-convergence.md` — 4 phases, seam checklist (S1–S12), critical path, success criteria, risks.
- `docs/plans/roadmap-v2.md` — milestone wired in: risk row, dependency lines (both directions), dependency-graph node, critical path, staffing.

**Skeleton (`src/embodied_ai_architect/graphs/`)**
- `design_state.py` — unified `DesignState` (subsumes `SoCDesignState` + `OptimizationLoopState`) + `DesignIssue`/`DesignDelta` currency + lifecycle helpers.
- `loop_agents.py` — `Critic` (promotes `reason_node`) and `Optimizer` (promotes `design_optimizer`) with LLM-plus-heuristic fallback, node wrappers, single router. MOO engine injected as a *tool*, not the loop body.
- `loop_convergence_graph.py` — `StateGraph` assembly + `MooTool` adapter over the real `OptimizationEngine` + seed/evaluate/recommend endpoints.

Tracked by **epic #203** (14 native sub-issues, phase- and severity-labeled). Start point: #204 (S1 schema audit).

## Type of Change

- [x] `feat`: New feature (minor version bump)
- [x] `docs`: Documentation only (no release)

## Testing

- [ ] Tests pass locally — full suite **not run**; skeleton is import-only and wired to nothing, so no behavior change. CI will validate.
- [x] Linting passes — `black --check` + `ruff check` clean on all three new modules.
- [ ] New tests added — intentionally none yet; each seam issue carries its own acceptance tests (e.g. S1 schema-audit test, S6 frontier-monotonicity test).

Note: the compiled graph drives a full failing→converged cycle with a fake MOO tool (verified interactively), but that harness is not yet checked in as a test — it lands with the Phase-2 issues.

## Conventional Commits

Two commits: `docs:` (roadmap) and `feat(graphs):` (skeleton). Suggested squash title: `feat(graphs): Loop Convergence roadmap + DRAFT skeleton`.

## Notes for Reviewers

- **Nothing is wired.** All three modules are import-only; no existing graph, CLI, or API path imports them. Safe to merge as scaffolding.
- **Key design decision to sanity-check:** the MOO engine becomes a *tool* the Optimizer calls (`MooTool` boundary) rather than being the loop body — this is the structural inversion the whole milestone rests on.
- **Schema-audit lesson (now issue #204):** a LangGraph `TypedDict` is the channel allowlist — any node write whose key isn't a declared `DesignState` channel is silently dropped at runtime. Found via `final_report`/`research_citations`/`pending_specialist_tasks`. The Phase-1 migration must audit every node write against the schema.
- Four deliberate seams remain stubbed (LLM critic prompt, real `_merge_pareto`, real `evaluate` via `ppa_assessor`, decompose/formulate front door) — each is a tracked sub-issue, not an oversight.

Refs #203


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified design-state model to track issues, proposed changes, and convergence across the design process.
  * Introduced structured critic and optimizer components to drive iterative improvements.
  * Added a draft “loop convergence” workflow that coordinates evaluation, optimization, and recommendations.
  * Expanded roadmap documentation to incorporate the loop-convergence milestone and updated release dependencies.

* **Chores**
  * Pinned formatter/linter versions to ensure consistent automated checks.
  * Improved formatting for server startup output and database setup statements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->