### PR TITLE
feat(graphs): DesignState channel audit + enforcing test (S1)

### DIFF
--- a/src/embodied_ai_architect/graphs/design_state.py
+++ b/src/embodied_ai_architect/graphs/design_state.py
@@ -62,6 +62,10 @@ __all__ = [
     "resolve_issue",
     "open_issues",
     "has_converged",
+    # Channel audit (Seam S1)
+    "declared_channels",
+    "undeclared_keys",
+    "assert_declared_channels",
 ]
 
 
@@ -316,6 +320,48 @@ class DesignState(TypedDict, total=False):
 
     # --- Error tracking (OptimizationLoopState) ---
     errors: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Channel audit (Seam S1) — the LangGraph allowlist guard
+# ---------------------------------------------------------------------------
+#
+# A LangGraph StateGraph merges each node's return dict into the state ONLY for
+# keys declared on the state schema. Any key a node returns that is not a
+# declared DesignState channel is silently dropped at runtime — a bug class with
+# no error and no stack trace (hit during the skeleton work with `final_report`,
+# `research_citations`, and `pending_specialist_tasks`). These helpers make the
+# invariant checkable so migrated nodes (S2a/S2b) can self-guard and tests can
+# enforce it.
+
+_DECLARED_CHANNELS: frozenset[str] = frozenset(DesignState.__annotations__)
+
+
+def declared_channels() -> frozenset[str]:
+    """Return the set of declared DesignState channels (the LangGraph allowlist)."""
+    return _DECLARED_CHANNELS
+
+
+def undeclared_keys(update: dict) -> set[str]:
+    """Return the keys in a node's return dict that are NOT declared channels.
+
+    Empty set == safe to merge. Non-empty == those keys would be silently dropped.
+    """
+    return set(update) - _DECLARED_CHANNELS
+
+
+def assert_declared_channels(update: dict, *, node: str = "") -> None:
+    """Raise if `update` contains any key that is not a declared DesignState channel.
+
+    Intended for node self-guarding: `assert_declared_channels(result, node="critic")`.
+    """
+    extra = undeclared_keys(update)
+    if extra:
+        where = f" from node '{node}'" if node else ""
+        raise KeyError(
+            f"DesignState update{where} contains keys not declared as channels: "
+            f"{sorted(extra)}. Declare them on DesignState or LangGraph will drop them."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_design_state_channels.py
+++ b/tests/test_design_state_channels.py
@@ -1,0 +1,185 @@
+"""Seam S1 (issue #204): DesignState schema audit — reconcile all node writes to channels.
+
+A LangGraph StateGraph merges a node's return dict into state ONLY for keys that
+are declared channels on the state schema. Any returned key that is NOT a declared
+`DesignState` field is silently dropped at runtime — no error, no stack trace. This
+test enforces the invariant: **every key any loop node writes must be a declared
+DesignState channel.**
+
+Scope note: today only the unified Loop Convergence nodes (`loop_agents` /
+`loop_convergence_graph`) flow through `DesignState`. The legacy dispatcher
+(`soc_graph`/`dispatcher`) and MOO loop (`optimization_loop`) nodes still use their
+own schemas; they get folded into this audit when they migrate (issues #205 / #206,
+seams S2a/S2b). The `NODE_WRITES` table below is the machine-checked mapping the
+issue asks for; extend it as nodes migrate.
+"""
+
+import pytest
+
+from embodied_ai_architect.graphs.design_state import (
+    DesignConstraints,
+    DesignState,
+    assert_declared_channels,
+    create_initial_design_state,
+    declared_channels,
+    undeclared_keys,
+)
+from embodied_ai_architect.graphs.loop_agents import (
+    critic_node,
+    optimizer_node,
+)
+from embodied_ai_architect.graphs.loop_convergence_graph import (
+    evaluate_node,
+    recommend_node,
+    seed_node,
+)
+
+# ---------------------------------------------------------------------------
+# The audit table: node -> fields it may write -> (all must be DesignState channels)
+# ---------------------------------------------------------------------------
+
+NODE_WRITES: dict[str, set[str]] = {
+    "seed_node": {"status", "design_space_config"},
+    "critic_node": {
+        "open_issues",
+        "pending_deltas",
+        "converged",
+        "analysis",
+        "research_citations",
+    },
+    "optimizer_node": {
+        "design_space_config",
+        "constraints",
+        "pending_specialist_tasks",
+        "applied_deltas",
+        "open_issues",
+        "pending_deltas",
+        "iteration",
+        # MOO-tool outputs re-emitted through the node's return value:
+        "pareto_points",
+        "pareto_frontier_history",
+        "hypervolume_history",
+        "knee_point",
+        "sensitivity",
+        "atlas",
+        "moo_results",
+    },
+    "evaluate_node": {"ppa_metrics"},
+    "recommend_node": {"status", "recommendation", "final_report"},
+    # The MOO engine tool merges into state via optimizer_node; its output-key
+    # contract must also be channels (mirrors make_moo_engine_tool._run).
+    "moo_tool": {
+        "pareto_points",
+        "pareto_frontier_history",
+        "hypervolume_history",
+        "knee_point",
+        "sensitivity",
+        "atlas",
+        "moo_results",
+    },
+}
+
+
+def _fake_moo_tool(state: DesignState) -> dict:
+    """Stand-in for make_moo_engine_tool's real adapter — same output-key contract."""
+    knee = {"objectives": {"power_watts": 4.0, "latency_ms": 20.0}}
+    return {
+        "pareto_points": [knee],
+        "pareto_frontier_history": [[knee]],
+        "hypervolume_history": list(state.get("hypervolume_history", [])) + [1.0],
+        "knee_point": knee,
+        "sensitivity": {"power": {"x": 1.0}},
+        "atlas": {"coverage": 0.5},
+        "moo_results": {"layers_used": ["map_elites"]},
+    }
+
+
+def _representative_state() -> DesignState:
+    """A state rich enough to drive every node down its populated path."""
+    state = create_initial_design_state(
+        "audit fixture",
+        constraints=DesignConstraints(max_power_watts=5.0, max_latency_ms=33.0),
+    )
+    state["llm_available"] = False
+    state["ppa_metrics"] = {"verdicts": {"power_watts": "FAIL", "latency_ms": "PASS"}}
+    return state
+
+
+def _run_all_nodes() -> dict[str, dict]:
+    """Drive the loop once, capturing each node's return dict."""
+    state = _representative_state()
+    results: dict[str, dict] = {}
+
+    results["seed_node"] = seed_node(state)
+    state.update(results["seed_node"])
+
+    results["critic_node"] = critic_node(state)
+    state.update(results["critic_node"])
+
+    results["moo_tool"] = _fake_moo_tool(state)
+
+    results["optimizer_node"] = optimizer_node(state, moo_tool=_fake_moo_tool)
+    state.update(results["optimizer_node"])
+
+    results["evaluate_node"] = evaluate_node(state)
+    state.update(results["evaluate_node"])
+
+    results["recommend_node"] = recommend_node(state)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: the table is valid, and no node writes an undeclared key.
+# ---------------------------------------------------------------------------
+
+
+def test_no_duplicate_channels():
+    """DesignState must not double-declare a channel (a duplicate silently shadows)."""
+    names = list(DesignState.__annotations__)
+    dupes = {n for n in names if names.count(n) > 1}
+    assert not dupes, f"DesignState has duplicate channel declarations: {sorted(dupes)}"
+
+
+@pytest.mark.parametrize("node,fields", sorted(NODE_WRITES.items()))
+def test_audit_table_only_references_declared_channels(node, fields):
+    """Every field in the checked-in table must be a declared DesignState channel."""
+    extra = fields - declared_channels()
+    assert not extra, f"NODE_WRITES['{node}'] references undeclared channels: {sorted(extra)}"
+
+
+@pytest.mark.parametrize("node", sorted(NODE_WRITES))
+def test_nodes_write_only_declared_channels(node):
+    """Running each node, every returned key must be a declared channel (S1 invariant)."""
+    produced = _run_all_nodes()[node]
+    dropped = undeclared_keys(produced)
+    assert not dropped, (
+        f"{node} returns keys that are NOT DesignState channels and would be "
+        f"silently dropped by LangGraph: {sorted(dropped)}"
+    )
+
+
+@pytest.mark.parametrize("node", sorted(NODE_WRITES))
+def test_nodes_stay_within_their_declared_table_entry(node):
+    """A node must not write keys outside its documented NODE_WRITES entry (drift guard)."""
+    produced = set(_run_all_nodes()[node])
+    undocumented = produced - NODE_WRITES[node]
+    assert not undocumented, (
+        f"{node} wrote keys absent from its NODE_WRITES entry: {sorted(undocumented)}. "
+        f"Update the audit table (and confirm they are DesignState channels)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# The guard helpers themselves.
+# ---------------------------------------------------------------------------
+
+
+def test_undeclared_keys_detects_bad_key():
+    assert undeclared_keys({"iteration": 1}) == set()
+    assert undeclared_keys({"iteration": 1, "not_a_channel": 9}) == {"not_a_channel"}
+
+
+def test_assert_declared_channels_raises_on_undeclared():
+    assert_declared_channels({"status": "exploring"})  # no raise
+    with pytest.raises(KeyError, match="not declared as channels"):
+        assert_declared_channels({"bogus_field": 1}, node="critic")

--- a/tests/test_design_state_channels.py
+++ b/tests/test_design_state_channels.py
@@ -14,6 +14,10 @@ seams S2a/S2b). The `NODE_WRITES` table below is the machine-checked mapping the
 issue asks for; extend it as nodes migrate.
 """
 
+import ast
+import inspect
+import textwrap
+
 import pytest
 
 from embodied_ai_architect.graphs.design_state import (
@@ -134,10 +138,23 @@ def _run_all_nodes() -> dict[str, dict]:
 
 
 def test_no_duplicate_channels():
-    """DesignState must not double-declare a channel (a duplicate silently shadows)."""
-    names = list(DesignState.__annotations__)
-    dupes = {n for n in names if names.count(n) > 1}
-    assert not dupes, f"DesignState has duplicate channel declarations: {sorted(dupes)}"
+    """DesignState must not double-declare a channel (a duplicate silently shadows).
+
+    `DesignState.__annotations__` is already deduplicated — a later declaration
+    overwrites an earlier one before this test could see it — so we inspect the
+    class *source* via AST to catch duplicates before Python collapses them.
+    """
+    tree = ast.parse(textwrap.dedent(inspect.getsource(DesignState)))
+    classdef = next(
+        n for n in ast.walk(tree) if isinstance(n, ast.ClassDef) and n.name == "DesignState"
+    )
+    names = [
+        node.target.id
+        for node in classdef.body
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name)
+    ]
+    dupes = sorted({n for n in names if names.count(n) > 1})
+    assert not dupes, f"DesignState has duplicate channel declarations: {dupes}"
 
 
 @pytest.mark.parametrize("node,fields", sorted(NODE_WRITES.items()))


### PR DESCRIPTION
## Summary

Implements **Seam S1** (issue #204) of the Loop Convergence epic: the `DesignState` schema audit.

A LangGraph `StateGraph` merges a node's return dict into state **only** for keys that are declared channels on the state schema. Any returned key that is not a declared `DesignState` field is silently dropped at runtime — no error, no stack trace (we hit this during the skeleton work with `final_report` / `research_citations` / `pending_specialist_tasks`). This PR makes the invariant checkable and enforces it.

**Guard helpers** (`graphs/design_state.py`) so migrated nodes can self-check:
- `declared_channels()` — the DesignState allowlist
- `undeclared_keys(update)` — keys that would be silently dropped
- `assert_declared_channels(update, node=...)` — raises with a clear message

**Audit + enforcing test** (`tests/test_design_state_channels.py`, 21 tests):
- `NODE_WRITES` — the checked-in node → fields → channel table the issue asks for
- The table only references declared channels
- Each loop node, when actually run, writes only declared channels (the S1 invariant)
- Drift guard: a node can't write keys outside its documented table entry
- Duplicate-channel guard (catches `research_citations`-style shadowing)
- Direct tests of the guard helpers

## Type of Change

- [x] `feat`: New feature (minor version bump)
- [x] `test`: Tests only

## Testing

- [x] `pytest tests/test_design_state_channels.py -q` → 21 passed
- [x] `black --check src/ tests/` + `ruff check src/ tests/` clean

## Scope

Only the unified Loop Convergence nodes (`loop_agents` / `loop_convergence_graph`) flow through `DesignState` today, so those are audited now. The legacy dispatcher (`soc_graph`/`dispatcher`) and MOO loop (`optimization_loop`) nodes still use their own schemas; they join the `NODE_WRITES` table when they migrate under #205 / #206 (seams S2a/S2b). This is stated in the test module docstring.

## Notes for Reviewers

- The audit is enforced by **running** the nodes and checking returned keys, not by static analysis — so it stays honest as the nodes evolve.
- `assert_declared_channels` is intended for node self-guarding once the migration lands (`assert_declared_channels(result, node="critic")`).

Closes #204. Part of #203.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added state-channel auditing helpers to enumerate valid state fields, detect undeclared updates, and raise clear errors before unsupported data is lost.
  * Introduced checks to ensure component writes remain within the declared state schema.

* **Tests**
  * Added an end-to-end audit suite verifying channels are unique, referenced writes are declared, and each node only returns expected state fields.
  * Added unit coverage for undeclared-key detection and error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->