### PR TITLE
feat(graphs): observable loop tracer + deterministic acceptance harness

### DIFF
--- a/src/embodied_ai_architect/graphs/loop_trace.py
+++ b/src/embodied_ai_architect/graphs/loop_trace.py
@@ -88,11 +88,19 @@ class LoopTrace:
         return "\n".join(lines)
 
 
+# A steering hook is called after the critic files its issues/deltas, before the
+# router runs. The operator receives the live state and may mutate it in place —
+# relax/tighten a constraint, drop or add an issue, or edit `pending_deltas` before
+# the optimizer applies them — to intercept and steer the loop. Return value ignored.
+SteerFn = Callable[[DesignState], None]
+
+
 def run_loop_traced(
     state: DesignState,
     *,
     moo_tool: MooTool,
     evaluate_fn: Optional[EvaluateFn] = None,
+    steer: Optional[SteerFn] = None,
     max_iterations: int = 6,
 ) -> LoopTrace:
     """Drive the unified loop over the real node functions, recording each step.
@@ -102,6 +110,9 @@ def run_loop_traced(
         moo_tool: the MOO-engine boundary the optimizer calls (a fake in tests).
         evaluate_fn: the evaluate step; defaults to the real `evaluate_node`
             (ppa_assessor). Inject a scripted one to drive a known verdict path.
+        steer: optional human-in-the-loop hook, called after the critic and before
+            routing with the live state, so an operator can intercept/steer the loop
+            (edit constraints, issues, or `pending_deltas`).
         max_iterations: backstop; also the router's convergence cap.
     """
     evaluate = evaluate_fn or evaluate_node
@@ -134,6 +145,16 @@ def run_loop_traced(
             upd.get("analysis", "") or "(no analysis)",
             issues=issue_lines,
         )
+
+        if steer is not None:
+            before = len(state.get("pending_deltas", []))
+            steer(state)
+            record(
+                "steer",
+                "operator intervened",
+                f"human-in-the-loop hook ran (pending_deltas {before} → "
+                f"{len(state.get('pending_deltas', []))})",
+            )
 
         route = router(state)
         record(

--- a/src/embodied_ai_architect/graphs/loop_trace.py
+++ b/src/embodied_ai_architect/graphs/loop_trace.py
@@ -1,0 +1,182 @@
+"""Observable, deterministic driver + tracer for the unified Loop Convergence loop.
+
+The compiled `loop_convergence_graph` runs its nodes inside LangGraph, which hides
+the intermediate steps. This module drives the same loop
+(seed → (critic → route → optimize → evaluate)* → recommend) *manually* using the
+real node functions, and records a `LoopTrace` — one `LoopStep` per node with the
+DECISION it made and the REASON why. It also logs each step to the
+`embodied_ai_architect.loop` logger.
+
+Use it to review loop behaviour ("why did it iterate / converge / apply that
+edit?") and as the engine behind the deterministic acceptance harness in
+`tests/test_loop_convergence_acceptance.py`.
+
+    trace = run_loop_traced(state, moo_tool=fake_tool)
+    print(trace.render())
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+from embodied_ai_architect.graphs.design_state import DesignState, open_issues
+from embodied_ai_architect.graphs.loop_agents import MooTool, critic_node, optimizer_node
+from embodied_ai_architect.graphs.loop_convergence_graph import (
+    evaluate_node,
+    make_router,
+    recommend_node,
+    seed_node,
+)
+
+logger = logging.getLogger("embodied_ai_architect.loop")
+
+# An evaluate step: state -> {"ppa_metrics": ...}. Defaults to the real evaluate_node
+# (which delegates to ppa_assessor). Scenarios can inject a scripted one to drive a
+# known verdict trajectory.
+EvaluateFn = Callable[[DesignState], dict]
+
+
+@dataclass
+class LoopStep:
+    """One node invocation: what it decided and why."""
+
+    iteration: int
+    node: str  # seed | critic | route | optimize | evaluate | recommend
+    decision: str  # short outcome
+    reason: str  # WHY the decision was made
+    detail: dict = field(default_factory=dict)
+
+
+@dataclass
+class LoopTrace:
+    steps: list[LoopStep]
+    final_state: DesignState
+
+    @property
+    def iterations(self) -> int:
+        return int(self.final_state.get("iteration", 0))
+
+    @property
+    def converged(self) -> bool:
+        return bool(self.final_state.get("converged", False))
+
+    @property
+    def final_verdicts(self) -> dict:
+        return dict(self.final_state.get("ppa_metrics", {}).get("verdicts", {}))
+
+    def nodes(self) -> list[str]:
+        return [s.node for s in self.steps]
+
+    def render(self) -> str:
+        """Human-readable trace: each step with its decision and reason."""
+        lines = ["Loop Convergence trace", "=" * 60]
+        for s in self.steps:
+            lines.append(f"[iter {s.iteration}] {s.node:<9} → {s.decision}")
+            if s.reason:
+                lines.append(f"            reason: {s.reason}")
+            for key in ("issues", "deltas"):
+                if s.detail.get(key):
+                    for item in s.detail[key]:
+                        lines.append(f"              - {item}")
+        lines.append("=" * 60)
+        lines.append(
+            f"converged={self.converged}  iterations={self.iterations}  "
+            f"verdicts={self.final_verdicts}"
+        )
+        return "\n".join(lines)
+
+
+def run_loop_traced(
+    state: DesignState,
+    *,
+    moo_tool: MooTool,
+    evaluate_fn: Optional[EvaluateFn] = None,
+    max_iterations: int = 6,
+) -> LoopTrace:
+    """Drive the unified loop over the real node functions, recording each step.
+
+    Args:
+        state: initial DesignState (constraints, and any seeded ppa_metrics).
+        moo_tool: the MOO-engine boundary the optimizer calls (a fake in tests).
+        evaluate_fn: the evaluate step; defaults to the real `evaluate_node`
+            (ppa_assessor). Inject a scripted one to drive a known verdict path.
+        max_iterations: backstop; also the router's convergence cap.
+    """
+    evaluate = evaluate_fn or evaluate_node
+    router = make_router(max_iterations)
+    steps: list[LoopStep] = []
+    state = dict(state)  # local copy; we mutate a working state
+
+    def record(node: str, decision: str, reason: str, **detail: object) -> None:
+        step = LoopStep(
+            iteration=int(state.get("iteration", 0)),
+            node=node,
+            decision=decision,
+            reason=reason,
+            detail=dict(detail),
+        )
+        steps.append(step)
+        logger.info("[iter %d] %-9s → %s :: %s", step.iteration, node, decision, reason)
+
+    state.update(seed_node(state))
+    record("seed", "initialized", "ensured design space + status before first review")
+
+    while True:
+        upd = critic_node(state)
+        state.update(upd)
+        issues = open_issues(state)
+        issue_lines = [f"{i.metric.value}: {i.summary} [{i.severity.value}]" for i in issues]
+        record(
+            "critic",
+            f"{len(issues)} open issue(s), converged={upd.get('converged')}",
+            upd.get("analysis", "") or "(no analysis)",
+            issues=issue_lines,
+        )
+
+        route = router(state)
+        record(
+            "route",
+            route,
+            (
+                "converged / backlog empty / iteration cap → recommend"
+                if route == "recommend"
+                else "open issues remain → optimize"
+            ),
+        )
+        if route == "recommend":
+            upd = recommend_node(state)
+            state.update(upd)
+            record("recommend", "final design selected", upd.get("final_report", ""))
+            break
+
+        upd = optimizer_node(state, moo_tool=moo_tool)
+        state.update(upd)
+        applied = state.get("applied_deltas", [])
+        recent = applied[-3:]
+        delta_lines = [
+            f"{d.get('kind')} {d.get('target')} :: {d.get('rationale', '')}"
+            + (
+                f"  (research: {', '.join(d.get('research_refs', []))})"
+                if d.get("research_refs")
+                else ""
+            )
+            for d in recent
+        ]
+        record(
+            "optimize",
+            f"applied {len(applied)} delta(s) cumulative",
+            "applied the critic's edits and re-ran the MOO tool",
+            deltas=delta_lines,
+        )
+
+        upd = evaluate(state)
+        state.update(upd)
+        record(
+            "evaluate",
+            f"verdicts={state.get('ppa_metrics', {}).get('verdicts', {})}",
+            "re-scored the design against constraints",
+        )
+
+    return LoopTrace(steps=steps, final_state=state)

--- a/tests/test_loop_convergence_acceptance.py
+++ b/tests/test_loop_convergence_acceptance.py
@@ -172,6 +172,27 @@ def test_real_evaluate_integration_terminates() -> None:
     assert isinstance(t.final_verdicts, dict)
 
 
+def test_operator_can_steer_the_loop() -> None:
+    """The steer hook lets an operator intercept the loop: here it force-converges
+    by clearing the backlog, so the loop recommends immediately at iteration 0."""
+
+    def force_converge(state: DesignState) -> None:
+        for issue in state.get("open_issues", []):
+            issue["status"] = "wontfix"  # operator accepts the trade-off
+        state["pending_deltas"] = []
+
+    t = run_loop_traced(
+        _initial_state(),
+        moo_tool=_fake_moo(),
+        evaluate_fn=_scripted_evaluate(pass_at_iter=999),  # would never converge on its own
+        steer=force_converge,
+        max_iterations=6,
+    )
+    assert t.iterations == 0  # operator short-circuited it
+    assert any(s.node == "steer" for s in t.steps)
+    assert t.steps[-1].node == "recommend"
+
+
 def test_trace_captures_the_reasoning() -> None:
     """The trace render must surface WHY the loop made its decisions."""
     rendered = _run(CONVERGES).render()

--- a/tests/test_loop_convergence_acceptance.py
+++ b/tests/test_loop_convergence_acceptance.py
@@ -1,0 +1,183 @@
+"""Deterministic acceptance harness for the unified Loop Convergence loop (Phase 2).
+
+Analogous to `gold_standards.py` for the dispatcher pipeline: each LoopScenario
+runs the real critic → optimize → evaluate → recommend loop over a fake MOO tool
+and a scripted verdict trajectory, and is checked against KNOWN targets
+(iterations, convergence, final verdicts, applied-delta count). The `LoopTrace`
+render is asserted to capture the reasoning ("why") behind each decision.
+"""
+
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from embodied_ai_architect.graphs.design_state import (
+    DesignState,
+    MetricAxis,
+    create_initial_design_state,
+)
+from embodied_ai_architect.graphs.loop_trace import EvaluateFn, LoopTrace, run_loop_traced
+from embodied_ai_architect.graphs.soc_state import DesignConstraints
+
+
+# ---------------------------------------------------------------------------
+# Harness building blocks
+# ---------------------------------------------------------------------------
+
+
+def _initial_state() -> DesignState:
+    state = create_initial_design_state(
+        "Drone perception at 5 m/s within 5W",
+        constraints=DesignConstraints(max_power_watts=5.0, max_latency_ms=33.0),
+    )
+    state["llm_available"] = False  # deterministic heuristic critic
+    state["ppa_metrics"] = {"verdicts": {"power": "FAIL"}}  # seed the first review
+    return state
+
+
+def _fake_moo() -> Callable[[DesignState], dict]:
+    """MOO tool whose knee design improves power each call, with a strictly
+    improving hypervolume (so the loop converges on the backlog/verdicts, not on a
+    hypervolume plateau — that plateau path is exercised separately)."""
+    calls = {"n": 0}
+
+    def tool(state: DesignState) -> dict:
+        calls["n"] += 1
+        power = max(8.0 - calls["n"] * 2.0, 3.0)
+        knee = {"objectives": {"power_watts": power, "latency_ms": 20.0}}
+        return {
+            "knee_point": knee,
+            "pareto_points": [knee],
+            # strictly increasing -> no plateau-triggered convergence
+            "hypervolume_history": state.get("hypervolume_history", []) + [float(calls["n"])],
+        }
+
+    return tool
+
+
+def _scripted_evaluate(pass_at_iter: int) -> EvaluateFn:
+    """Verdicts follow a known trajectory: power FAIL until `pass_at_iter`, then PASS."""
+
+    def ev(state: DesignState) -> dict:
+        it = int(state.get("iteration", 0))
+        verdict = "PASS" if it >= pass_at_iter else "FAIL"
+        ppa = dict(state.get("ppa_metrics", {}))
+        ppa["verdicts"] = {"power": verdict}
+        return {"ppa_metrics": ppa}
+
+    return ev
+
+
+@dataclass
+class LoopScenario:
+    name: str
+    description: str
+    evaluate_fn: Optional[EvaluateFn]
+    max_iterations: int
+    # Known targets:
+    expected_iterations: int
+    expected_converged: bool
+    expected_verdicts: dict
+    expected_applied_deltas: int
+
+
+def _run(scenario: LoopScenario) -> LoopTrace:
+    return run_loop_traced(
+        _initial_state(),
+        moo_tool=_fake_moo(),
+        evaluate_fn=scenario.evaluate_fn,
+        max_iterations=scenario.max_iterations,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scenarios with known output targets
+# ---------------------------------------------------------------------------
+
+CONVERGES = LoopScenario(
+    name="converges_after_fixing_power",
+    description="power fails for 2 iterations, then the fix lands and the loop converges",
+    evaluate_fn=_scripted_evaluate(pass_at_iter=2),
+    max_iterations=6,
+    expected_iterations=2,
+    expected_converged=True,
+    expected_verdicts={"power": "PASS"},
+    expected_applied_deltas=2,
+)
+
+HITS_CAP = LoopScenario(
+    name="hits_iteration_cap",
+    description="power never passes; the loop stops at the iteration cap, not converged",
+    evaluate_fn=_scripted_evaluate(pass_at_iter=999),
+    max_iterations=3,
+    expected_iterations=3,
+    expected_converged=False,
+    expected_verdicts={"power": "FAIL"},
+    expected_applied_deltas=3,
+)
+
+
+def test_scenario_converges_after_fix() -> None:
+    t = _run(CONVERGES)
+    assert t.iterations == CONVERGES.expected_iterations
+    assert t.converged is CONVERGES.expected_converged
+    assert t.final_verdicts == CONVERGES.expected_verdicts
+    assert len(t.final_state.get("applied_deltas", [])) == CONVERGES.expected_applied_deltas
+    # the critic flagged power as the bottleneck it was optimizing
+    critic_steps = [s for s in t.steps if s.node == "critic"]
+    assert any(
+        MetricAxis.POWER.value in i for s in critic_steps for i in s.detail.get("issues", [])
+    )
+    # the loop ended by recommending, not by hitting the cap
+    assert t.steps[-1].node == "recommend"
+
+
+def test_scenario_converges_on_hypervolume_plateau() -> None:
+    """When the MOO frontier stops improving (constant hypervolume) the loop
+    converges even though the verdict still fails — the plateau is a valid stop
+    signal (`has_converged`)."""
+
+    def flat_moo(state: DesignState) -> dict:
+        knee = {"objectives": {"power_watts": 6.0, "latency_ms": 20.0}}
+        return {
+            "knee_point": knee,
+            "pareto_points": [knee],
+            "hypervolume_history": state.get("hypervolume_history", []) + [1.0],  # flat
+        }
+
+    t = run_loop_traced(
+        _initial_state(),
+        moo_tool=flat_moo,
+        evaluate_fn=_scripted_evaluate(pass_at_iter=999),  # power never passes
+        max_iterations=6,
+    )
+    # Stopped well before the cap, via the hypervolume-plateau signal.
+    assert t.iterations < 6
+    assert t.steps[-1].node == "recommend"
+
+
+def test_scenario_hits_iteration_cap() -> None:
+    t = _run(HITS_CAP)
+    assert t.iterations == HITS_CAP.expected_iterations
+    assert t.converged is HITS_CAP.expected_converged
+    assert t.final_verdicts == HITS_CAP.expected_verdicts
+    assert len(t.final_state.get("applied_deltas", [])) == HITS_CAP.expected_applied_deltas
+
+
+def test_real_evaluate_integration_terminates() -> None:
+    """With the real evaluate_node (ppa_assessor), the loop still terminates and
+    produces verdicts — proving the S7 assessor integrates into the traced loop."""
+    t = run_loop_traced(_initial_state(), moo_tool=_fake_moo(), evaluate_fn=None, max_iterations=4)
+    assert t.steps[-1].node == "recommend"
+    assert t.iterations <= 4
+    assert isinstance(t.final_verdicts, dict)
+
+
+def test_trace_captures_the_reasoning() -> None:
+    """The trace render must surface WHY the loop made its decisions."""
+    rendered = _run(CONVERGES).render()
+    assert "power" in rendered  # the bottleneck the critic reasoned about
+    assert "reason:" in rendered  # every decision carries a reason
+    assert "→ recommend" in rendered or "recommend" in rendered
+    assert "converged=True" in rendered
+    # the optimizer's edits and their rationale appear
+    assert "applied" in rendered


### PR DESCRIPTION
## Summary

A deterministic **acceptance harness** + **step tracer** for the unified Loop Convergence loop, so the Phase-2 critic/optimizer work can be reviewed against known targets and its decisions inspected.

Motivation: the dispatcher pipeline has `TracingDispatcher` + gold standards, but the **new unified loop had no step logger and no known-target acceptance loop** — only unit tests. This adds both.

## What's new

### `graphs/loop_trace.py` — the observable runner (the "why" logger)
`run_loop_traced(state, moo_tool=…, evaluate_fn=…, max_iterations=…)` drives the real `seed → (critic → route → optimize → evaluate)* → recommend` loop **manually over the actual node functions** (the compiled `StateGraph` hides intermediate steps) and records a `LoopTrace` — one `LoopStep` per node with the **decision** and the **reason why**:
- critic: open issues (metric + summary + severity) and its `analysis`
- optimize: the deltas applied, their rationale and research refs
- evaluate: the verdicts
- route / recommend: why it iterated vs. converged

It also logs each step to the `embodied_ai_architect.loop` logger, and `LoopTrace.render()` prints a human-readable trace. Example:

```
[iter 0] critic    → 1 open issue(s), converged=False
            reason: 1 failing constraint(s); proposed 1 edit(s).
              - power: power constraint failing [critical]
[iter 0] route     → optimize
            reason: open issues remain → optimize
[iter 1] optimize  → applied 1 delta(s) cumulative
              - design_space_edit quantization_dtype :: Heuristic edit to relieve power bottleneck
...
[iter 2] critic    → 0 open issue(s), converged=True
            reason: No failing constraints; frontier stable — recommend.
```

### `tests/test_loop_convergence_acceptance.py` — the harness
Gold-standard-style `LoopScenario`s with **known targets** (iterations, convergence, final verdicts, applied-delta count), run over a fake MOO tool + a scripted verdict trajectory:
- **converge-on-fix** — power fails 2 iters then passes → converges at iter 2, 2 deltas applied, ends in `recommend`
- **converge-on-hypervolume-plateau** — frontier stops improving → converges via `has_converged` even with a failing verdict
- **hit-iteration-cap** — verdict never passes, hypervolume keeps improving → stops at the cap, not converged
- **real-evaluate integration** — uses the real `evaluate_node`/`ppa_assessor` and still terminates
- **trace-captures-the-reasoning** — asserts the rendered trace surfaces the bottleneck, the reasons, and the convergence

## Testing

- [x] 5 acceptance scenarios pass; `black`+`ruff` clean; channel-audit regression green

## Notes for Reviewers

- This is **review/observability tooling**, not a numbered seam. It's the natural precursor to S11 (wiring the architect skills to a real loop iteration) and S12 (convergence tuning) — both benefit from an inspectable, target-checked loop.
- The harness itself already earned its keep: it surfaced that a constant-hypervolume fake tool triggers the plateau convergence path (a real `has_converged` signal), which I then covered as an explicit scenario.

Part of #203.
