### PR TITLE
docs: loop-convergence demonstration + runnable demo

### DIFF
--- a/docs/demos/loop_convergence_demo.py
+++ b/docs/demos/loop_convergence_demo.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python
+"""Loop Convergence demo — an agentic loop solving a real SoC design problem.
+
+Problem
+-------
+Design the compute SoC for a delivery-drone perception pipeline that must fit:
+
+    power   <= 5.0 W
+    latency <= 33.0 ms
+    cost    <= 30.0 $
+
+We start from a naive design that busts the power and latency budgets, and let the
+loop converge to a feasible design. At each iteration:
+
+    critic    finds the bottlenecks (as typed DesignIssues) and proposes edits
+              (typed DesignDeltas)
+    optimizer applies the edits to the design space and re-runs the MOO tool
+    evaluate  re-scores the resulting design against the constraints
+    router    decides whether to iterate again or recommend
+
+Everything the agents do is streamed to the `embodied_ai_architect.loop` logger,
+so you can watch the reasoning live (see `--log`), and an operator can intercept
+and steer the loop via a hook (see `steered_run`).
+
+Run
+---
+    python docs/demos/loop_convergence_demo.py          # autonomous solve
+    python docs/demos/loop_convergence_demo.py --log    # + live agent log
+    python docs/demos/loop_convergence_demo.py --steer  # operator intervention
+
+This demo uses a deterministic *surrogate* MOO tool (no botorch/pymoo/API key
+needed) that models how the SoC design space responds to the loop's edits, so the
+solve is reproducible. Swap `surrogate_moo` for
+`graphs.loop_convergence_graph.make_moo_engine_tool()` to drive the real
+MAP-Elites/Bayesian optimizer instead.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+from embodied_ai_architect.graphs.design_state import (
+    DeltaKind,
+    DesignDelta,
+    DesignState,
+    create_initial_design_state,
+)
+from embodied_ai_architect.graphs.loop_trace import run_loop_traced
+from embodied_ai_architect.graphs.soc_state import DesignConstraints
+
+# --- The problem ---------------------------------------------------------------
+
+CONSTRAINTS = DesignConstraints(max_power_watts=5.0, max_latency_ms=33.0, max_cost_usd=30.0)
+
+
+def initial_state() -> DesignState:
+    """A naive drone-perception SoC that busts power and latency."""
+    state = create_initial_design_state(
+        "Delivery-drone perception SoC: detection + tracking + VIO at 5 m/s",
+        constraints=CONSTRAINTS,
+    )
+    state["platform"] = "drone"
+    state["llm_available"] = False  # deterministic heuristic critic (no API key)
+    # Naive starting point: FP32 on a big generic accelerator -> over budget.
+    state["ppa_metrics"] = {"verdicts": {"power": "FAIL", "latency": "FAIL"}}
+    return state
+
+
+# --- Surrogate MOO tool: models how the design space responds to the loop's edits
+
+
+def surrogate_moo(state: DesignState) -> dict:
+    """Return a knee design whose PPA reflects the edits the loop has applied.
+
+    Baseline FP32 / small systolic array: 8.0 W, 45 ms, $26. The loop's edits move
+    it: INT8 quantization cuts power and latency; a larger MAC array cuts latency.
+    """
+    space = state.get("design_space_config", {})
+    hw = space.get("hardware", {})
+
+    power, latency, cost = 8.0, 45.0, 26.0
+    if space.get("quantization_dtype") == "int8":
+        power *= 0.55  # INT8 MACs are far cheaper
+        latency *= 0.7
+    if hw.get("array_rows") == 32:
+        latency *= 0.55  # 4x MACs -> lower latency
+        power *= 1.05  # slightly more power for the bigger array
+    if space.get("sparsity") == "structured":
+        power *= 0.83  # structured sparsity skips zero MACs (operator's lever)
+
+    knee = {
+        "objectives": {
+            "power_watts": round(power, 1),
+            "latency_ms": round(latency, 1),
+            "cost_usd": round(cost, 1),
+        },
+        "design_params": {
+            "quantization_dtype": space.get("quantization_dtype", "fp32"),
+            "array_rows": hw.get("array_rows", 8),
+        },
+    }
+    return {
+        "knee_point": knee,
+        "pareto_points": [knee],
+        # improving hypervolume so convergence is driven by the verdicts, not a plateau
+        "hypervolume_history": state.get("hypervolume_history", [])
+        + [float(len(state.get("hypervolume_history", [])) + 1)],
+    }
+
+
+def score_knee(state: DesignState) -> dict:
+    """Evaluate step: score the current knee design against the constraints.
+
+    (The shipped `evaluate_node` delegates to the architecture-level `ppa_assessor`;
+    here we score the MOO knee point directly so the demo narrative tracks the
+    design the loop is actually optimizing.)
+    """
+    point = state.get("knee_point", {})
+    obj = point.get("objectives", {})
+    c = state.get("constraints", {})
+    verdicts = {}
+    for name, key, limit in (
+        ("power", "power_watts", c.get("max_power_watts")),
+        ("latency", "latency_ms", c.get("max_latency_ms")),
+        ("cost", "cost_usd", c.get("max_cost_usd")),
+    ):
+        val = obj.get(key)
+        if val is not None and limit is not None:
+            verdicts[name] = "PASS" if float(val) <= float(limit) else "FAIL"
+    ppa = dict(state.get("ppa_metrics", {}))
+    ppa.update({k: obj.get(k) for k in ("power_watts", "latency_ms", "cost_usd")})
+    ppa["verdicts"] = verdicts
+    return {"ppa_metrics": ppa}
+
+
+# --- Runs ----------------------------------------------------------------------
+
+
+def autonomous_run() -> None:
+    print("\n=== Autonomous solve: drone SoC, <=5W / <=33ms / <=$30 ===\n")
+    trace = run_loop_traced(initial_state(), moo_tool=surrogate_moo, evaluate_fn=score_knee)
+    print(trace.render())
+    final = trace.final_state.get("knee_point", {}).get("objectives", {})
+    print(f"\nFinal design: {final}")
+    print(f"Converged: {trace.converged} in {trace.iterations} iteration(s)\n")
+
+
+def steered_run() -> None:
+    """Two operator interventions show steering is *productive*:
+
+    1. A late requirement change tightens the power budget 5.0 -> 4.0 W.
+    2. INT8 alone only reaches 4.6 W, so the critic's power lever is exhausted and
+       the loop would stall. The operator, watching the log, injects a design move
+       the heuristic critic didn't know about — structured sparsity — which the
+       optimizer applies and the loop then converges under 4.0 W.
+    """
+    print("\n=== Steered solve: operator tightens budget, then unblocks the loop ===\n")
+
+    tightened = {"done": False}
+
+    def steer(state: DesignState) -> None:
+        if not tightened["done"]:
+            tightened["done"] = True
+            state.setdefault("constraints", {})["max_power_watts"] = 4.0
+            print("   >>> operator: late requirement — tighten max_power_watts 5.0 -> 4.0 W\n")
+            return
+        # Loop stuck on power with INT8 already applied? Inject a fresh lever.
+        verdicts = state.get("ppa_metrics", {}).get("verdicts", {})
+        space = state.get("design_space_config", {})
+        if (
+            verdicts.get("power") == "FAIL"
+            and space.get("quantization_dtype") == "int8"
+            and space.get("sparsity") != "structured"
+        ):
+            print("   >>> operator: INT8 exhausted at 4.6W — injecting structured sparsity\n")
+            state.setdefault("pending_deltas", []).append(
+                DesignDelta(
+                    kind=DeltaKind.DESIGN_SPACE_EDIT,
+                    target="sparsity",
+                    change={"value": "structured"},
+                    rationale="operator: structured sparsity to close the last 0.6W",
+                    proposed_by="operator",
+                ).model_dump(mode="json")
+            )
+
+    trace = run_loop_traced(
+        initial_state(), moo_tool=surrogate_moo, evaluate_fn=score_knee, steer=steer
+    )
+    print(trace.render())
+    final = trace.final_state.get("knee_point", {}).get("objectives", {})
+    print(f"\nFinal design: {final}  (met the tightened 4.0W budget via operator's sparsity move)")
+    print(f"Converged: {trace.converged} in {trace.iterations} iteration(s)\n")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--log", action="store_true", help="stream the agent log live")
+    ap.add_argument("--steer", action="store_true", help="run the operator-steered variant")
+    args = ap.parse_args()
+
+    if args.log:
+        # Concurrent tracking: everything the agents do streams to this logger.
+        h = logging.StreamHandler(sys.stdout)
+        h.setFormatter(logging.Formatter("  LOG | %(message)s"))
+        loop_logger = logging.getLogger("embodied_ai_architect.loop")
+        loop_logger.setLevel(logging.INFO)
+        loop_logger.addHandler(h)
+
+    if args.steer:
+        steered_run()
+    else:
+        autonomous_run()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/loop-convergence-demo.md
+++ b/docs/loop-convergence-demo.md
@@ -1,0 +1,183 @@
+# Loop Convergence — a demonstration
+
+This walks through the **Loop Convergence** agentic loop solving a real SoC design
+problem end-to-end: you can watch each agent reason, track the log live, and
+intercept the loop to steer it. It exists to build confidence that the loop is
+*productive* — that it actually converges on a feasible design and tells you *why*.
+
+> Run it yourself:
+> ```bash
+> python docs/demos/loop_convergence_demo.py            # autonomous solve
+> python docs/demos/loop_convergence_demo.py --log      # + live agent log
+> python docs/demos/loop_convergence_demo.py --steer    # operator intervention
+> ```
+> The demo uses a deterministic *surrogate* MOO tool (no botorch/pymoo/API key
+> needed) that models how the SoC design space responds to the loop's edits, so
+> the solve is reproducible. Swap it for `make_moo_engine_tool()` to drive the
+> real MAP-Elites/Bayesian optimizer.
+
+---
+
+## The problem
+
+Design the compute SoC for a delivery-drone perception pipeline (detection +
+tracking + VIO at 5 m/s) that must fit a hard budget:
+
+| Constraint | Budget |
+|---|---|
+| Power | ≤ 5.0 W |
+| Latency | ≤ 33.0 ms |
+| Cost | ≤ 30.0 $ |
+
+We start from a **naive design that busts power and latency** (FP32 on a small
+generic accelerator: 8.0 W / 45 ms) and let the loop find a feasible design.
+
+## The loop
+
+Every iteration runs four agents over one shared `DesignState`:
+
+```
+        ┌─────────── critic ──────────┐
+        │ finds bottlenecks as typed  │
+        │ DesignIssues, proposes typed│
+        │ DesignDeltas (the edits)    │
+        └──────────────┬──────────────┘
+                       │  (optional operator steer hook)
+                       ▼
+        ┌──────────── router ─────────┐   recommend
+        │ converged / backlog empty / ├──────────────▶ done
+        │ iteration cap → recommend;  │
+        │ else → optimize             │
+        └──────────────┬──────────────┘
+                       ▼ optimize
+        ┌─────────── optimizer ───────┐
+        │ applies the deltas to the   │
+        │ design space, re-runs the   │
+        │ MOO tool                    │
+        └──────────────┬──────────────┘
+                       ▼
+        ┌─────────── evaluate ────────┐
+        │ re-scores the design vs the │
+        │ constraints → verdicts      │
+        └──────────────┬──────────────┘
+                       └──────────▶ back to critic
+```
+
+- **critic** — reviews `ppa_metrics.verdicts` + the Pareto front + the open-issue
+  backlog (and, with an API key, retrieved research) and emits a `CriticVerdict`
+  of typed `DesignIssue`s and `DesignDelta`s.
+- **optimizer** — applies the deltas as concrete design-space edits and calls the
+  MOO tool (a boundary, not the loop body).
+- **evaluate** — re-scores the resulting design (the shipped node delegates to the
+  same `ppa_assessor` the dispatcher pipeline uses).
+- **router** — one stop condition: converged, empty backlog, or the iteration cap.
+
+## 1. Autonomous solve
+
+```
+[iter 0] critic    → 2 open issue(s), converged=False
+            reason: 2 failing constraint(s); proposed 2 edit(s).
+              - power: power constraint failing [critical]
+              - latency: latency constraint failing [critical]
+[iter 0] route     → optimize
+[iter 1] optimize  → applied 2 delta(s) cumulative
+              - design_space_edit quantization_dtype  :: relieve power bottleneck
+              - design_space_edit hardware.array_rows :: relieve latency bottleneck
+[iter 1] evaluate  → verdicts={'power': 'PASS', 'latency': 'PASS', 'cost': 'PASS'}
+[iter 1] critic    → 0 open issue(s), converged=True
+            reason: No failing constraints; frontier stable — recommend.
+[iter 1] route     → recommend
+============================================================
+converged=True  iterations=1  verdicts={'power': 'PASS', 'latency': 'PASS', 'cost': 'PASS'}
+
+Final design: {'power_watts': 4.6, 'latency_ms': 17.3, 'cost_usd': 26.0}
+```
+
+**8.0 W / 45 ms (both failing) → 4.6 W / 17.3 ms, all constraints met, in one
+iteration.** The critic identified *both* bottlenecks, chose the right levers
+(INT8 quantization for power, a 4× larger MAC array for latency), and the loop
+confirmed feasibility and stopped. Every decision carries a reason.
+
+## 2. Tracking the log concurrently
+
+Everything the agents do streams to the `embodied_ai_architect.loop` logger. Attach
+a handler (the demo's `--log` flag does this) and you get a live feed you can tail,
+pipe to a file, or forward to a dashboard while the loop runs:
+
+```python
+import logging, sys
+h = logging.StreamHandler(sys.stdout)
+h.setFormatter(logging.Formatter("  LOG | %(message)s"))
+lg = logging.getLogger("embodied_ai_architect.loop")
+lg.setLevel(logging.INFO)
+lg.addHandler(h)
+```
+
+```
+  LOG | [iter 0] critic    → 2 open issue(s), converged=False :: 2 failing constraint(s); proposed 2 edit(s).
+  LOG | [iter 0] route     → optimize :: open issues remain → optimize
+  LOG | [iter 1] optimize  → applied 2 delta(s) cumulative :: applied the critic's edits and re-ran the MOO tool
+  LOG | [iter 1] evaluate  → verdicts={'power': 'PASS', 'latency': 'PASS', 'cost': 'PASS'} :: re-scored...
+  LOG | [iter 1] critic    → 0 open issue(s), converged=True :: No failing constraints; frontier stable — recommend.
+```
+
+The same data is also captured structurally in the `LoopTrace` (`trace.steps`,
+`trace.render()`) for post-hoc review.
+
+## 3. Intercepting and steering the loop
+
+`run_loop_traced(..., steer=hook)` invokes an operator hook **after the critic and
+before the optimizer**, with the live `DesignState`. The operator can relax/tighten
+a constraint, drop or add an issue, or **edit `pending_deltas`** — injecting a design
+move the critic didn't propose. This is how a human keeps the loop on-mission.
+
+In this run the operator makes two interventions:
+
+1. A **late requirement change** tightens the power budget 5.0 → 4.0 W.
+2. INT8 alone only reaches 4.6 W, so the critic's power lever is *exhausted* and the
+   loop would stall. Watching the log, the operator **injects structured sparsity**
+   — a lever the heuristic critic didn't know about — and the loop converges.
+
+```
+[iter 0] steer     → operator intervened  (late requirement: tighten 5.0 → 4.0 W)
+[iter 1] optimize  → applied 2 delta(s)   (INT8 + bigger MAC array)
+[iter 1] evaluate  → verdicts={'power': 'FAIL', 'latency': 'PASS', 'cost': 'PASS'}   # 4.6 W > 4.0 W
+[iter 1] critic    → 1 open issue(s)       (power still failing; only lever is INT8, already applied)
+[iter 1] steer     → operator intervened  (inject: sparsity=structured)
+[iter 2] optimize  → applied 4 delta(s)
+              - design_space_edit sparsity :: operator: structured sparsity to close the last 0.6W
+[iter 2] evaluate  → verdicts={'power': 'PASS', 'latency': 'PASS', 'cost': 'PASS'}   # 3.8 W < 4.0 W
+[iter 2] critic    → 0 open issue(s), converged=True
+============================================================
+converged=True  iterations=2  verdicts={'power': 'PASS', 'latency': 'PASS', 'cost': 'PASS'}
+
+Final design: {'power_watts': 3.8, 'latency_ms': 17.3, 'cost_usd': 26.0}
+```
+
+This is the point of the demo: **the loop and the engineer collaborate.** The loop
+does the mechanical search and reports honestly when a lever is exhausted; the human
+supplies domain knowledge (a new design move, a requirement change) and the loop
+incorporates it and reconverges — under a *harder* 4.0 W budget.
+
+## Why this builds confidence
+
+- **It converges on a feasible design**, not just "runs" — 8 W → 3.8 W under a
+  tightened budget, with all constraints met.
+- **Every step is explained** — which bottleneck, which edit, why it iterated or
+  stopped — so the output is auditable, not a black box.
+- **It fails honestly** — when a lever is exhausted it says so instead of pretending;
+  that's what makes the steer hook necessary and useful.
+- **A human can steer it** at any iteration, so it's a co-pilot, not an oracle.
+
+## What's real vs. illustrative here
+
+- **Real:** the `critic` → `optimizer` → `evaluate` → `router` loop, the typed
+  `DesignIssue`/`DesignDelta` flow, the convergence logic, the trace/logger, and the
+  steer hook are the shipped Phase-2 code (`graphs/loop_agents.py`,
+  `graphs/loop_convergence_graph.py`, `graphs/loop_trace.py`).
+- **Illustrative:** the `surrogate_moo` design-space response and `score_knee`
+  evaluate are demo stand-ins so the solve is deterministic and dependency-free.
+  In production, `make_moo_engine_tool()` drives the real MAP-Elites/Bayesian
+  optimizer over the 17-variable joint design space, and `evaluate_node` delegates
+  to the real `ppa_assessor`. Wiring these into a CLI command with an LLM critic is
+  the remaining Phase 4 work (S10–S11).


### PR DESCRIPTION
A user-facing demonstration (doc + runnable script) that the Phase-2 Loop Convergence loop is productive: solves a drone-perception SoC problem (<=5W/<=33ms/<=$30) end-to-end, streams the live agent log, and shows an operator steering the loop (tighten budget + inject a design lever) to reconverge under a harder budget. Deterministic surrogate MOO tool; documents the real-engine swap. Part of #203.