### PR TITLE
feat(graphs): real decompose/formulate front door in seed_node (S10)

### DIFF
--- a/docs/plans/roadmap-loop-convergence.md
+++ b/docs/plans/roadmap-loop-convergence.md
@@ -183,7 +183,7 @@ remaining work is filling these named seams:
 | S7 | **Real `evaluate_node`** — replace the deterministic constraint check with the actual `ppa_assessor` so verdicts match the rest of the pipeline. | `loop_convergence_graph.py` | 2 | ☑ (#212) |
 | S8 | **Specialist retask execution** — `SPECIALIST_RETASK` deltas enqueue `pending_specialist_tasks`; the dispatcher must consume them and re-run the named specialist (issue #35-style re-validation after a config change). | `loop_agents.py`, `dispatcher.py` | 3 | ☑ (#214) |
 | S9 | **Specialist agents + estimator tools** — wrap `physical_estimators.py` / `specialists.py` as verdict-first tools; promote the 2–3 judgment-bearing specialists to agents. | `specialists.py`, `physical_estimators.py` | 3 | ☑ (#213) |
-| S10 | **Decompose/formulate front door** — `seed_node` stands in for the real mission → constraints → joint design space entry (reuse `MissionDecomposer` + `create_joint_design_space`). | `loop_convergence_graph.py`, `research/decomposer.py` | 4 | ☐ |
+| S10 | **Decompose/formulate front door** — `seed_node` stands in for the real mission → constraints → joint design space entry (reuse `MissionDecomposer` + `create_joint_design_space`). | `loop_convergence_graph.py`, `research/decomposer.py` | 4 | ☑ (#215) |
 | S11 | **Wire architect skills to the loop** — add `branes session iterate` running one code-level loop iteration; rewrite `architect-loop.md` to invoke it instead of orchestrating CLI calls. | CLI, `.claude/commands/architect-loop.md` | 4 | ☐ |
 | S12 | **Convergence tuning** — `has_converged` uses a fixed hypervolume epsilon; calibrate against real runs and add the critic's "diminishing returns" judgment as a third signal. | `design_state.py`, `loop_agents.py` | 4 | ☐ |
 

--- a/src/embodied_ai_architect/graphs/loop_convergence_graph.py
+++ b/src/embodied_ai_architect/graphs/loop_convergence_graph.py
@@ -152,14 +152,53 @@ def evaluate_node(state: DesignState) -> dict:
 
 
 def seed_node(state: DesignState) -> dict:
-    """Entry: ensure a design space + one initial frontier exist before the first review.
+    """Front door (S10): NL mission → constraints → joint design space.
 
-    In the full system this also runs decompose/formulate (mission → constraints →
-    joint design space); here it just guarantees the fields the loop needs.
+    Given a `mission_description` (or `goal`), runs the `MissionDecomposer` and
+    `create_joint_design_space` so a single mission string seeds a valid DesignState
+    with no manual setup. If the state is already seeded, or no mission / decompose
+    fails, falls back to a minimal design-space stub so the loop still runs.
     """
     updates: dict = {"status": "exploring"}
-    if not state.get("design_space_config"):
-        updates["design_space_config"] = {"source": "default_joint_space"}
+    if state.get("design_space_config"):
+        return updates  # already seeded
+
+    try:
+        from embodied_ai_architect.graphs.moo.joint_design_space import create_joint_design_space
+        from embodied_ai_architect.graphs.soc_state import DesignConstraints
+
+        if state.get("constraints"):
+            # Constraints already set — just materialize a joint design space.
+            constraints = dict(state["constraints"])
+        else:
+            # No constraints: decompose the NL mission into constraints (S10).
+            mission = state.get("mission_description") or state.get("goal")
+            if not mission:
+                updates["design_space_config"] = {"source": "default_joint_space"}
+                return updates
+            from embodied_ai_architect.research.decomposer import (
+                MissionDecomposer,
+                plan_to_constraints,
+            )
+
+            plan = MissionDecomposer(llm_client=None).decompose(mission)
+            constraints = DesignConstraints(**plan_to_constraints(plan)).model_dump()
+            updates["constraints"] = constraints
+            updates["platform"] = plan.platform
+            updates["mission_type"] = plan.mission_type
+            updates["mission_plan"] = plan.model_dump()
+
+        ds = create_joint_design_space(constraints={**constraints, "include_accuracy": True})
+        updates["design_space_config"] = {
+            "num_variables": ds.n_var,
+            "num_objectives": ds.n_obj,
+            "objectives": ds.objectives,
+            "constraint_bounds": {k: list(v) for k, v in ds.constraint_bounds.items()},
+            "source": "mission_decomposer",
+        }
+    except Exception:  # pragma: no cover - decompose/joint-space best effort
+        updates.setdefault("design_space_config", {"source": "default_joint_space"})
+
     return updates
 
 

--- a/src/embodied_ai_architect/research/decomposer.py
+++ b/src/embodied_ai_architect/research/decomposer.py
@@ -549,3 +549,40 @@ Respond with JSON only, no markdown fences."""
             total_estimated_gflops=round(total_gflops, 2),
             end_to_end_latency_budget_ms=e2e_latency_ms,
         )
+
+
+# ---------------------------------------------------------------------------
+# MissionPlan -> DesignConstraints mapping (Seam S10)
+# ---------------------------------------------------------------------------
+
+# MissionPlan design-space constraint names -> DesignConstraints field names.
+_CONSTRAINT_FIELD = {
+    "power_watts": "max_power_watts",
+    "latency_ms": "max_latency_ms",
+    "cost_usd": "max_cost_usd",
+    "area_mm2": "max_area_mm2",
+    "accuracy_percent": "min_accuracy_percent",
+    "weight_grams": "max_weight_grams",
+    "volume_cm3": "max_volume_cm3",
+}
+
+
+def plan_to_constraints(plan: MissionPlan) -> dict[str, Any]:
+    """Map a MissionPlan's design-space constraints onto DesignConstraints fields.
+
+    Returns a plain dict (e.g. {"max_power_watts": 5.0, "max_latency_ms": 33.3,
+    "workload_type": "detection", "quantization_dtype": "int8"}) suitable for
+    constructing a DesignConstraints and for `create_joint_design_space`. Kept
+    here (graph-independent) so the loop's front door can reuse it.
+    """
+    ds = plan.design_space
+    out: dict[str, Any] = {}
+    for c in getattr(ds, "constraints", []) or []:
+        field = _CONSTRAINT_FIELD.get(c.name)
+        if field is not None and c.value is not None:
+            out[field] = c.value
+    if getattr(ds, "workload_type", None):
+        out["workload_type"] = ds.workload_type
+    if getattr(ds, "quantization_dtype", None):
+        out["quantization_dtype"] = ds.quantization_dtype
+    return out

--- a/tests/test_front_door.py
+++ b/tests/test_front_door.py
@@ -1,0 +1,53 @@
+"""Seam S10 (issue #215): the loop front door — an NL mission string seeds a valid
+DesignState (constraints + joint design space) with no manual setup."""
+
+from embodied_ai_architect.graphs.design_state import DesignState
+from embodied_ai_architect.graphs.loop_convergence_graph import seed_node
+from embodied_ai_architect.research.decomposer import MissionDecomposer, plan_to_constraints
+
+
+def test_nl_mission_seeds_constraints_and_design_space() -> None:
+    state: DesignState = {
+        "mission_description": "Delivery-drone perception at 5 m/s: detection + "
+        "tracking + VIO, 5W power budget, 33ms latency",
+    }
+    out = seed_node(state)
+
+    # constraints inferred from the mission (no manual setup)
+    assert out["constraints"]["max_power_watts"] == 5.0
+    assert out["constraints"]["max_latency_ms"] is not None
+    # a real joint design space was materialized
+    dsc = out["design_space_config"]
+    assert dsc["source"] == "mission_decomposer"
+    assert dsc["num_variables"] >= 17  # hw + pipeline + NAS + compiler
+    assert dsc["num_objectives"] >= 3
+    # mission context carried through
+    assert out["platform"] == "drone"
+    assert out["mission_type"]
+    assert "mission_plan" in out
+
+
+def test_existing_constraints_build_space_without_decompose() -> None:
+    """If constraints are already set, the front door materializes a design space
+    from them and does not overwrite them."""
+    state: DesignState = {"constraints": {"max_power_watts": 8.0, "max_latency_ms": 20.0}}
+    out = seed_node(state)
+    assert "constraints" not in out  # untouched
+    assert out["design_space_config"]["num_variables"] >= 17
+
+
+def test_no_mission_falls_back_to_stub() -> None:
+    out = seed_node({})
+    assert out["design_space_config"] == {"source": "default_joint_space"}
+
+
+def test_already_seeded_is_noop() -> None:
+    out = seed_node({"design_space_config": {"num_variables": 17}})
+    assert set(out) == {"status"}
+
+
+def test_plan_to_constraints_maps_named_constraints() -> None:
+    plan = MissionDecomposer(llm_client=None).decompose("Drone perception, 5W, 33ms")
+    c = plan_to_constraints(plan)
+    assert c["max_power_watts"] == 5.0
+    assert "max_latency_ms" in c and "workload_type" in c


### PR DESCRIPTION
Seam S10 (#215): seed_node turns an NL mission into a valid DesignState (constraints + 17-var joint design space) with no manual setup, via MissionDecomposer + create_joint_design_space. plan_to_constraints maps a MissionPlan onto DesignConstraints fields. Falls back gracefully when constraints exist / no mission. Closes #215. Part of #203.