### PR TITLE
feat(cli): wire architect skills to the code loop via session iterate (S11)

### DIFF
--- a/.claude/commands/architect-assess.md
+++ b/.claude/commands/architect-assess.md
@@ -2,6 +2,12 @@ Generate the multi-level metrics dashboard for the current design state.
 
 This is the "where am I" command — shows metrics at every level of abstraction so the architect can quickly identify what needs attention.
 
+> **Bottlenecks are now typed `DesignIssue`s.** When the state has `open_issues`
+> (filed by the loop's critic + specialist agents — see `/architect-loop`), treat
+> that as the authoritative "what needs attention" list: each issue carries
+> `metric`, `level`, `severity`, `observed_value` vs `target_value`, and
+> `contribution_pct`. Surface the open issues alongside the raw metrics.
+
 ## How to get the state
 
 Load the most recent design session from disk:

--- a/.claude/commands/architect-drill.md
+++ b/.claude/commands/architect-drill.md
@@ -1,5 +1,10 @@
 Deep-dive analysis of a specific bottleneck target: $ARGUMENTS
 
+> **Pick the target from `open_issues`.** The loop's critic + specialist agents file
+> typed `DesignIssue`s (see `/architect-loop`); when the state has `open_issues`,
+> the target usually corresponds to the highest-`severity` / highest-`contribution_pct`
+> issue. Each issue names its `metric`, `level`, and `component` — start the drill there.
+
 The target can be:
 - A subsystem (perception, control)
 - An operator (yolo_detector, tracker, vio)

--- a/.claude/commands/architect-loop.md
+++ b/.claude/commands/architect-loop.md
@@ -1,100 +1,83 @@
 Run one iteration of the architect's bottleneck-hunting loop on the current design.
 
-This is the core expert skill: assess → rank bottlenecks → drill down → propose options.
+As of the Loop Convergence work (epic #203), this loop is a **real code path** — the
+`critic`, the specialist agents (PPA, thermal), the `optimizer`, and `evaluate` — not
+manual CLI orchestration. Your job is to invoke it and interpret the result for the
+user, and to steer it when domain knowledge is needed.
 
-## How to get the state
-
-Load the most recent design session:
+## 1. Run one iteration
 
 ```bash
-.venv/bin/branes session show --latest --json
+.venv/bin/branes session iterate --latest          # or: iterate <session_id> -n <N>
 ```
 
-This returns the full `SoCDesignState` JSON. The key fields you need:
-- `ppa_metrics` — current power, latency, area, cost with verdicts
-- `constraints` — target budgets
-- `optimization_review_snapshot` — constraint slackness, trajectory, strategy analysis
-- `optimization_history` — PPA snapshots across iterations
-- `workload_profile` — per-operator compute requirements
-- `selected_architecture` — hardware mapping
-- `design_rationale` — decision trail
-- `iteration` — which iteration we're on
+This runs the unified loop over the persisted `DesignState`:
 
-If no session exists, tell the user:
+- the **critic** + **specialist agents** file typed `DesignIssue`s for the bottlenecks
+  (with research-grounded rationale when an LLM key is set),
+- the **optimizer** applies concrete `DesignDelta` edits and re-runs the MOO engine
+  over the 17-variable joint design space,
+- **evaluate** re-scores the design via the same `ppa_assessor` the pipeline uses,
+- the mutated state is **saved**, and the command prints the full reasoning trace —
+  what each agent decided and *why*, step by step.
+
+If there is no session, tell the user:
 ```
 No active design session. Start one with:
   branes design qualify "your design goal"
   branes design plan "your qualified goal" --power X --latency Y
 ```
 
-## Steps
+## 2. Read back what the loop did
 
-1. **Assess current state**: From the session JSON, extract:
-   - All PPA metrics vs constraints (PASS/FAIL for each)
-   - Constraint slackness (margin %, trend direction)
-   - Current optimization iteration number
+```bash
+.venv/bin/branes session show --latest --json
+```
 
-2. **Rank the top 3 bottlenecks across ALL metrics**: Look at:
-   - Which constraints are FAIL? By how much?
-   - Which passing constraints have <10% headroom? (about to fail)
-   - Which operator/subsystem consumes the most of each resource?
-   - Is memory bandwidth saturated? (`workload_profile` has BW data)
-   - Is utilization unbalanced? (one IP block at 90%, another at 20%)
+The bottleneck analysis is now structured data (you no longer hand-derive it):
 
-   **Use MOO sensitivity to break ties** (issue #24): when `optimization_review_snapshot.sensitivity` is populated, two metrics that look equally bad are not equally easy to fix. The metric whose primary driver has high MOO sensitivity is the higher-leverage bottleneck — moving that knob will actually shift the metric. Prefer to escalate that one to the top of the ranking.
+- `open_issues` — the typed bottlenecks the critic + specialists filed: `metric`,
+  `level` (system/subsystem/operator/kernel/hardware/physical), `severity`,
+  `summary`, `observed_value` vs `target_value`, `contribution_pct`.
+- `applied_deltas` — the concrete edits the optimizer applied: `kind`, `target`,
+  `rationale`, and `research_refs` grounding them.
+- `ppa_metrics.verdicts` — PASS/FAIL per constraint; `converged`; `iteration`.
+- `optimization_review_snapshot.sensitivity` — MOO per-variable leverage (use it
+  only to add color on which knob actually moves a metric).
 
-   Example: power and cost both fail by 10%. Sensitivity says `clock_mhz` impacts power at 0.90 but `process_nm` impacts cost at only 0.20 — power is the higher-leverage bottleneck even though they're tied numerically, because there's a real knob to turn.
+## 3. Present a situation report
 
-   For each of the top 3:
-   - Name it and locate it (system/subsystem/operator/kernel level)
-   - Quantify the gap (actual vs target, % over budget)
-   - Show trend from `optimization_history` (improving, worsening, stable)
-   - Classify: compute-bound, memory-bound, thermally-limited, cost-dominated
+1. **Top bottlenecks** — from `open_issues`, ranked by `severity` then
+   `contribution_pct`. For each: the metric, its level, the gap (observed vs target,
+   % over budget), and why it's the dominant one.
+2. **What the loop did** — from `applied_deltas` and the printed trace: which edits it
+   applied, their rationale, any research it cited.
+3. **Where it stands** — the verdicts, whether it `converged`, and iteration `N`. If it
+   didn't converge, name what still fails and the loop's next lever.
+4. **Recommendation / next step** — run another iteration, or steer.
 
-3. **Drill down on bottleneck #1**: Run additional analysis:
-   - For compute: `.venv/bin/branes mcp analyze --model <model>` for kernel breakdown
-   - For cost: `.venv/bin/branes swap estimate --area X --power Y --process Z` for cost decomposition
-   - For power: check `ip_blocks` config for clock/voltage settings
-   - For latency: check per-operator latency from `workload_profile`
-   - **Use sensitivity to find the right knob**: Read
-     `optimization_review_snapshot.sensitivity` (issue #24). It maps each
-     design variable to its impact on each objective (0–1 score from the BO
-     layer). For the failing metric, sort variables by their impact on that
-     specific objective and pick the top 1-2 — those are the highest-leverage
-     knobs to turn. Example: if power is failing and `quantization_dtype` has
-     impact 0.82 on power but `noc_link_width_bits` has impact 0.04, propose
-     changing the dtype not the NoC width.
+```
+ARCHITECT LOOP — iteration N
 
-4. **Propose 3-5 concrete options** from the strategy catalog:
-   Read `optimization_review_snapshot.strategies` for what's available vs tried.
-   For each option: estimated impact on bottleneck AND side effects on other metrics.
-   Flag any option that would flip a passing constraint to FAIL.
+TOP BOTTLENECKS (from open_issues):
+  1. [metric] at [level]: [observed] vs [target] (+[contribution_pct]%, [severity])
+  2. ...
+WHAT THE LOOP DID (from applied_deltas):
+  - [kind] [target] :: [rationale]  (research: [research_refs])
+STATUS: verdicts=[...], converged=[bool]
+NEXT: [iterate again | steer]
+```
 
-5. **Summarize as situation report**:
-   ```
-   ARCHITECT LOOP — Iteration N/M
+## 4. Steer when the loop needs domain knowledge
 
-   TOP 3 BOTTLENECKS:
-     1. [name] at [level]: [metric] = [value] vs [target] ([margin]% headroom, [trend])
-     2. ...
-     3. ...
+The loop reports honestly when a lever is exhausted (e.g. INT8 alone can't hit a
+tightened power budget). When that happens — or when the user wants a different
+trade-off — steer it:
 
-   DRILL-DOWN on #1:
-     [detailed analysis from step 3]
+- **Relax/tighten a constraint** and re-run `session iterate`.
+- **Inject a design move** the critic didn't propose (e.g. structured sparsity, a
+  smaller process node) via the loop's steer hook — see
+  `docs/loop-convergence-demo.md` for a worked example.
 
-   OPTIONS:
-     A. [action] — est. [impact] on [metric], side effect: [effect]
-     B. ...
-
-   RECOMMENDATION: [which option and reasoning]
-   ```
-
-Do NOT choose or execute — present the analysis and let the architect decide.
-
-## How to apply the architect's decision
-
-When the architect picks an option, the next step depends on whether we have an active interactive session:
-
-- If running interactively: use `steer_optimization` tool in `branes chat`
-- If using the pipeline: modify the state and re-run the dispatch step
-- For quick what-if: `.venv/bin/branes swap score --area X --power Y --process Z --profile drone`
+The old manual bottleneck-ranking is now the critic + specialists' job. You are the
+interpreter and the human-in-the-loop steersman.

--- a/docs/plans/roadmap-loop-convergence.md
+++ b/docs/plans/roadmap-loop-convergence.md
@@ -184,7 +184,7 @@ remaining work is filling these named seams:
 | S8 | **Specialist retask execution** — `SPECIALIST_RETASK` deltas enqueue `pending_specialist_tasks`; the dispatcher must consume them and re-run the named specialist (issue #35-style re-validation after a config change). | `loop_agents.py`, `dispatcher.py` | 3 | ☑ (#214) |
 | S9 | **Specialist agents + estimator tools** — wrap `physical_estimators.py` / `specialists.py` as verdict-first tools; promote the 2–3 judgment-bearing specialists to agents. | `specialists.py`, `physical_estimators.py` | 3 | ☑ (#213) |
 | S10 | **Decompose/formulate front door** — `seed_node` stands in for the real mission → constraints → joint design space entry (reuse `MissionDecomposer` + `create_joint_design_space`). | `loop_convergence_graph.py`, `research/decomposer.py` | 4 | ☑ (#215) |
-| S11 | **Wire architect skills to the loop** — add `branes session iterate` running one code-level loop iteration; rewrite `architect-loop.md` to invoke it instead of orchestrating CLI calls. | CLI, `.claude/commands/architect-loop.md` | 4 | ☐ |
+| S11 | **Wire architect skills to the loop** — add `branes session iterate` running one code-level loop iteration; rewrite `architect-loop.md` to invoke it instead of orchestrating CLI calls. | CLI, `.claude/commands/architect-loop.md` | 4 | ☑ (#216) |
 | S12 | **Convergence tuning** — `has_converged` uses a fixed hypervolume epsilon; calibrate against real runs and add the critic's "diminishing returns" judgment as a third signal. | `design_state.py`, `loop_agents.py` | 4 | ☐ |
 
 ---

--- a/src/embodied_ai_architect/cli/commands/session.py
+++ b/src/embodied_ai_architect/cli/commands/session.py
@@ -287,3 +287,58 @@ def session_delete(ctx, session_id, yes):
 
     store.delete(session_id)
     console.print(f"[green]Deleted session {session_id}[/green]")
+
+
+@session.command("iterate")
+@click.argument("session_id", required=False)
+@click.option("--latest", is_flag=True, help="Iterate the most recent session")
+@click.option("--iterations", "-n", default=1, show_default=True, help="Loop iterations to run")
+@click.pass_context
+def session_iterate(ctx, session_id, latest, iterations):
+    """Run the unified loop-convergence loop over a saved session (S11).
+
+    Runs the critic -> optimize -> evaluate loop for N iterations, mutates the
+    persisted DesignState, and prints the reasoning trace (what each agent did and
+    why). This is the code-level iteration the `architect-loop` skill invokes.
+
+    \\b
+    Examples:
+      branes session iterate --latest
+      branes session iterate soc_abc123 -n 3
+    """
+    from embodied_ai_architect.graphs.design_state import open_issues
+    from embodied_ai_architect.graphs.loop_convergence_graph import make_moo_engine_tool
+    from embodied_ai_architect.graphs.loop_trace import run_loop_traced
+    from embodied_ai_architect.graphs.session_store import SessionStore
+
+    store = SessionStore()
+    if latest:
+        state = store.load_latest()
+    elif session_id:
+        state = store.load(session_id)
+    else:
+        console.print("[red]Provide a session ID or use --latest.[/red]")
+        return
+    if not state:
+        console.print("[yellow]No matching session. Start one first.[/yellow]")
+        return
+
+    # Real MOO engine, wrapped so an engine / optional-dependency error degrades to
+    # a no-op instead of aborting the iteration.
+    engine = make_moo_engine_tool()
+
+    def moo_tool(s):
+        try:
+            return engine(s)
+        except Exception:
+            return {}
+
+    trace = run_loop_traced(state, moo_tool=moo_tool, max_iterations=iterations)
+    sid = store.save(trace.final_state)
+
+    console.print(trace.render())
+    console.print(
+        f"[green]Session {sid} updated[/green] — converged={trace.converged}, "
+        f"iterations={trace.iterations}, open_issues={len(open_issues(trace.final_state))}, "
+        f"verdicts={trace.final_verdicts}"
+    )

--- a/tests/test_session_iterate_cli.py
+++ b/tests/test_session_iterate_cli.py
@@ -1,0 +1,90 @@
+"""Seam S11 (issue #216): `branes session iterate` runs a real loop iteration over a
+persisted DesignState and saves the mutated state."""
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from embodied_ai_architect.cli.commands.session import session
+from embodied_ai_architect.graphs import session_store as ss_mod
+from embodied_ai_architect.graphs.design_state import DesignConstraints
+from embodied_ai_architect.graphs.session_store import SessionStore
+
+
+@pytest.fixture()
+def store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> SessionStore:
+    # Point the store the CLI constructs at a temp dir.
+    monkeypatch.setattr(ss_mod, "DEFAULT_SESSION_DIR", tmp_path)
+    return SessionStore(tmp_path)
+
+
+def _fake_moo_tool_factory():
+    def tool(state):
+        knee = {"objectives": {"power_watts": 4.0, "latency_ms": 20.0}}
+        return {
+            "knee_point": knee,
+            "pareto_points": [knee],
+            "hypervolume_history": state.get("hypervolume_history", []) + [1.0],
+        }
+
+    return tool
+
+
+def _seed_session(store: SessionStore) -> str:
+    state = {
+        "session_id": "soc_test123",
+        "goal": "drone perception SoC",
+        "constraints": DesignConstraints(max_power_watts=5.0, max_latency_ms=33.0).model_dump(),
+        "ppa_metrics": {"verdicts": {"power": "FAIL"}, "power_watts": 8.0},
+        "llm_available": False,
+        "iteration": 0,
+    }
+    return store.save(state)
+
+
+def test_iterate_runs_and_persists_mutated_state(
+    store: SessionStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Use a fast, deterministic MOO tool instead of the real engine.
+    import embodied_ai_architect.graphs.loop_convergence_graph as lcg
+
+    monkeypatch.setattr(lcg, "make_moo_engine_tool", _fake_moo_tool_factory)
+
+    sid = _seed_session(store)
+    before = store.load(sid)
+
+    result = CliRunner().invoke(session, ["iterate", sid, "-n", "1"])
+
+    assert result.exit_code == 0, result.output
+    assert "Loop Convergence trace" in result.output
+    assert f"Session {sid} updated" in result.output
+
+    # the persisted state was mutated by the loop
+    after = store.load(sid)
+    assert after is not None
+    assert after.get("status") == "complete" or after.get("iteration", 0) >= before.get(
+        "iteration", 0
+    )
+
+
+def test_iterate_latest(store: SessionStore, monkeypatch: pytest.MonkeyPatch) -> None:
+    import embodied_ai_architect.graphs.loop_convergence_graph as lcg
+
+    monkeypatch.setattr(lcg, "make_moo_engine_tool", _fake_moo_tool_factory)
+    _seed_session(store)
+    result = CliRunner().invoke(session, ["iterate", "--latest"])
+    assert result.exit_code == 0, result.output
+    assert "updated" in result.output
+
+
+def test_iterate_no_session_is_graceful(store: SessionStore) -> None:
+    result = CliRunner().invoke(session, ["iterate", "--latest"])
+    assert result.exit_code == 0
+    assert "No matching session" in result.output
+
+
+def test_iterate_requires_target(store: SessionStore) -> None:
+    result = CliRunner().invoke(session, ["iterate"])
+    assert result.exit_code == 0
+    assert "Provide a session ID or use --latest" in result.output


### PR DESCRIPTION
Seam S11 (#216): `branes session iterate` runs N real loop-convergence iterations over a persisted DesignState (critic + specialists -> optimizer -> evaluate, real MOO engine, safe-wrapped) and saves the mutated state with a reasoning trace. architect-loop.md rewritten to invoke it; architect-drill/assess read open_issues. Verified end-to-end with the real engine. Closes #216. Part of #203.