### PR TITLE
feat(graphs): convergence tuning + critic diminishing-returns signal (S12)

### DIFF
--- a/docs/plans/roadmap-loop-convergence.md
+++ b/docs/plans/roadmap-loop-convergence.md
@@ -185,7 +185,7 @@ remaining work is filling these named seams:
 | S9 | **Specialist agents + estimator tools** — wrap `physical_estimators.py` / `specialists.py` as verdict-first tools; promote the 2–3 judgment-bearing specialists to agents. | `specialists.py`, `physical_estimators.py` | 3 | ☑ (#213) |
 | S10 | **Decompose/formulate front door** — `seed_node` stands in for the real mission → constraints → joint design space entry (reuse `MissionDecomposer` + `create_joint_design_space`). | `loop_convergence_graph.py`, `research/decomposer.py` | 4 | ☑ (#215) |
 | S11 | **Wire architect skills to the loop** — add `branes session iterate` running one code-level loop iteration; rewrite `architect-loop.md` to invoke it instead of orchestrating CLI calls. | CLI, `.claude/commands/architect-loop.md` | 4 | ☑ (#216) |
-| S12 | **Convergence tuning** — `has_converged` uses a fixed hypervolume epsilon; calibrate against real runs and add the critic's "diminishing returns" judgment as a third signal. | `design_state.py`, `loop_agents.py` | 4 | ☐ |
+| S12 | **Convergence tuning** — `has_converged` uses a fixed hypervolume epsilon; calibrate against real runs and add the critic's "diminishing returns" judgment as a third signal. | `design_state.py`, `loop_agents.py` | 4 | ☑ (#217) |
 
 ---
 

--- a/src/embodied_ai_architect/graphs/design_state.py
+++ b/src/embodied_ai_architect/graphs/design_state.py
@@ -399,6 +399,7 @@ class DesignState(TypedDict, total=False):
     max_iterations: int
     converged: bool
     should_iterate: bool
+    critic_diminishing_returns: bool  # critic judged further iteration won't help (S12)
     llm_available: bool  # gates the reasoning agents' LLM path (read by critic_node)
 
     # --- History / governance / cost (SoCDesignState) ---
@@ -552,15 +553,36 @@ def open_issues(state: DesignState) -> list[DesignIssue]:
     return sorted((i for i in issues if i.is_open), key=lambda i: order[i.severity])
 
 
-def has_converged(state: DesignState, *, hypervolume_epsilon: float = 1e-3) -> bool:
-    """Unified stop condition (replaces the two separate ones).
+def has_converged(
+    state: DesignState,
+    *,
+    hypervolume_rel_epsilon: float = 0.01,
+    plateau_window: int = 2,
+) -> bool:
+    """Single stop condition for the loop (the iteration cap is the router's job).
 
-    Converged when EITHER the issue backlog is empty OR the Pareto hypervolume has
-    stopped improving — whichever the loop reaches first.
+    Converges when ANY of these holds (S12):
+
+    1. **Empty backlog** — no open issues left to fix.
+    2. **Critic diminishing returns** — the critic judged further iteration won't
+       help even if constraints still fail (`critic_diminishing_returns`).
+    3. **Hypervolume plateau** — the Pareto hypervolume's *relative* change stays
+       below `hypervolume_rel_epsilon` across the last `plateau_window` steps.
+
+    The relative, windowed plateau (vs. the old single-step absolute epsilon) was
+    calibrated on the loop-convergence demo / acceptance runs so that one flat step
+    doesn't prematurely stop a search that is still improving, while a genuinely
+    stalled frontier is caught.
     """
     if not open_issues(state):
         return True
-    hv = state.get("hypervolume_history", [])
-    if len(hv) >= 2 and abs(hv[-1] - hv[-2]) < hypervolume_epsilon:
+    if state.get("critic_diminishing_returns"):
         return True
+    hv = state.get("hypervolume_history", [])
+    if len(hv) > plateau_window:
+        recent = hv[-(plateau_window + 1) :]
+        base = max(abs(recent[-1]), 1.0)
+        steps = [abs(recent[i + 1] - recent[i]) / base for i in range(len(recent) - 1)]
+        if all(s < hypervolume_rel_epsilon for s in steps):
+            return True
     return False

--- a/src/embodied_ai_architect/graphs/loop_agents.py
+++ b/src/embodied_ai_architect/graphs/loop_agents.py
@@ -63,7 +63,11 @@ class CriticVerdict(BaseModel):
         default_factory=list, description="Concrete edits proposed to close the issues"
     )
     converged: bool = Field(
-        default=False, description="Critic judges diminishing returns — stop the loop"
+        default=False, description="No failing constraints and the frontier is stable"
+    )
+    diminishing_returns: bool = Field(
+        default=False,
+        description="Critic judges further iteration won't help even if constraints fail (S12)",
     )
     analysis: str = Field(default="", description="Human-readable rationale")
     research_citations: list[str] = Field(default_factory=list)
@@ -110,6 +114,7 @@ issue, every fix is a delta that names a design-space variable or constraint.
 Respond with JSON only, in exactly this shape:
 {
   "converged": false,
+  "diminishing_returns": false,
   "analysis": "one short paragraph",
   "research_citations": ["doc/path.md", ...],
   "issues": [
@@ -145,8 +150,11 @@ Per-kind `change` payloads:
 - specialist_retask      -> {"reason": "..."}     (plus any extra keys)
 
 Rules: set "converged": true only when no constraint is failing AND further search
-would not help. Each delta's "addresses_issue" is the 0-based index into "issues".
-Prefer edits to high-contribution / high-severity issues first."""
+would not help. Set "diminishing_returns": true when further iteration is unlikely
+to help even though constraints still fail (the levers are exhausted) — this stops
+the loop and asks the operator to steer. Each delta's "addresses_issue" is the
+0-based index into "issues". Prefer edits to high-contribution / high-severity
+issues first."""
 
 
 class Critic(ReasoningAgent):
@@ -301,6 +309,7 @@ has converged. Respond with JSON only."""
             issues=issues,
             deltas=deltas,
             converged=converged,
+            diminishing_returns=_coerce_bool(data.get("diminishing_returns", False)),
             analysis=str(data.get("analysis", "")),
             research_citations=list(data.get("research_citations", []) or []),
         )
@@ -438,6 +447,7 @@ def critic_node(state: DesignState) -> dict:
         "open_issues": state.get("open_issues", []),
         "pending_deltas": state.get("pending_deltas", []),
         "converged": verdict.converged,
+        "critic_diminishing_returns": verdict.diminishing_returns,
         "analysis": verdict.analysis,
         "research_citations": verdict.research_citations,
     }

--- a/tests/test_convergence_tuning.py
+++ b/tests/test_convergence_tuning.py
@@ -1,0 +1,99 @@
+"""Seam S12 (issue #217): the single convergence condition — empty backlog OR
+critic diminishing-returns OR relative windowed hypervolume plateau (the iteration
+cap is the router's job)."""
+
+import json
+
+from embodied_ai_architect.graphs.design_state import (
+    AbstractionLevel,
+    DesignIssue,
+    DesignState,
+    MetricAxis,
+    Severity,
+    has_converged,
+)
+from embodied_ai_architect.graphs.loop_agents import Critic
+
+
+def _issue_state(**hv: object) -> DesignState:
+    """A state with one open issue (backlog non-empty) so convergence must come
+    from a signal other than the empty backlog."""
+    issue = DesignIssue(
+        metric=MetricAxis.POWER,
+        level=AbstractionLevel.SYSTEM,
+        severity=Severity.HIGH,
+        summary="power failing",
+        raised_by="test",
+    )
+    return {"open_issues": [issue.model_dump(mode="json")], **hv}
+
+
+# ---------------------------------------------------------------------------
+# The three convergence signals
+# ---------------------------------------------------------------------------
+
+
+def test_empty_backlog_converges() -> None:
+    assert has_converged({"open_issues": []}) is True
+
+
+def test_diminishing_returns_converges_even_with_open_issues() -> None:
+    state = _issue_state(hypervolume_history=[1.0, 2.0, 4.0])  # still improving
+    assert has_converged(state) is False
+    state["critic_diminishing_returns"] = True
+    assert has_converged(state) is True
+
+
+def test_relative_windowed_plateau_converges() -> None:
+    # Flat frontier over the window -> converged despite an open issue.
+    assert has_converged(_issue_state(hypervolume_history=[5.0, 5.0, 5.0])) is True
+
+
+def test_single_flat_step_does_not_prematurely_converge() -> None:
+    # One flat step inside an otherwise-improving run must NOT stop the loop
+    # (the old absolute single-step epsilon would have).
+    assert has_converged(_issue_state(hypervolume_history=[1.0, 2.0, 2.0])) is False
+
+
+def test_steadily_improving_frontier_does_not_converge() -> None:
+    assert has_converged(_issue_state(hypervolume_history=[1.0, 2.0, 3.0, 4.0])) is False
+
+
+# ---------------------------------------------------------------------------
+# The critic emits the diminishing-returns judgment (LLM path)
+# ---------------------------------------------------------------------------
+
+
+class _Stub:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _Client:
+    def __init__(self, text: str) -> None:
+        self._t = text
+
+    def chat(self, messages, system):  # noqa: ANN001
+        return _Stub(self._t)
+
+
+def test_critic_parses_diminishing_returns() -> None:
+    payload = json.dumps(
+        {
+            "converged": False,
+            "diminishing_returns": True,
+            "issues": [{"metric": "power", "severity": "high", "summary": "stuck"}],
+            "deltas": [],
+        }
+    )
+    state = {"ppa_metrics": {"verdicts": {"power": "FAIL"}}}
+    verdict = Critic(llm_available=True, llm_client=_Client(payload)).review(state)
+    assert verdict.diminishing_returns is True
+
+
+def test_critic_diminishing_returns_string_false_is_falsey() -> None:
+    payload = json.dumps({"diminishing_returns": "false", "issues": [], "deltas": []})
+    v = Critic(llm_available=True, llm_client=_Client(payload)).review(
+        {"ppa_metrics": {"verdicts": {"power": "PASS"}}}
+    )
+    assert v.diminishing_returns is False

--- a/tests/test_design_state_channels.py
+++ b/tests/test_design_state_channels.py
@@ -60,6 +60,7 @@ NODE_WRITES: dict[str, set[str]] = {
         "open_issues",
         "pending_deltas",
         "converged",
+        "critic_diminishing_returns",
         "analysis",
         "research_citations",
     },


### PR DESCRIPTION
Seam S12 (#217): single has_converged() stop condition — empty backlog OR critic diminishing-returns OR a relative, windowed hypervolume plateau (calibrated so a lone flat step doesn't prematurely stop). Critic emits a diminishing_returns judgment when levers are exhausted. Closes #217. Completes Phase 4 (and the epic's seam checklist). Part of #203.